### PR TITLE
Compatibility for Windows Dev Environments

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
 	"semi": true,
 	"singleQuote": true,
 	"trailingComma": "es5",
-	"useTabs": true
+	"useTabs": true,
+	"endOfLine": "auto"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,
 	"git.branchProtection": ["main"],
-	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**"]
+	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**"],
+	"files.eol": "auto"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
 	"git.branchProtection": ["main"],
 	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**"],
 	"files.eol": "auto",
-	"terminal.integrated.defaultProfile.windows": "Git Bash"
+	"terminal.integrated.defaultProfile.windows": "Git Bash",
+	"editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
 	"editor.insertSpaces": false,
 	"git.branchProtection": ["main"],
 	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**"],
-	"files.eol": "auto"
+	"files.eol": "auto",
+	"terminal.integrated.defaultProfile.windows": "Git Bash"
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you're on Windows, `npm` scripts will not work unless you tell `npm` to use G
 Before continuing, run this command:
 
 ```sh
-npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+$ npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
 ```
 
 You must have [Git for Windows](https://git-scm.com/download/win) installed. See this [StackOverflow answer](https://stackoverflow.com/a/46006249) for more details.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ DISCORD_TOKEN=YOUR_TOKEN_GOES_HERE
 
 Go to https://discordapi.com/permissions.html#378091424832 and paste in your bot's client ID to get an invite link.
 
+### Important Note for Windows Users
+
+If you're on Windows, `npm` scripts will not working unless you tell `npm` to use Git Bash as its default shell when running commands.
+
+Before continuing, run this command:
+
+```sh
+npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+```
+
+You must have [Git for Windows](https://git-scm.com/download/win) installed. See this [StackOverflow answer](https://stackoverflow.com/a/46006249) for more details.
+
 ### Build the bot server
 
 Be sure to install dependencies, and run a quick lint to generate needed files:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This list is updated as contributors contribute.
     - [Get your own bot token](#get-your-own-bot-token)
     - [Configure the bot](#configure-the-bot)
     - [Invite your bot to your server](#invite-your-bot-to-your-server)
+    - [Important Note for Windows Users](#important-note-for-windows-users)
     - [Build the bot server](#build-the-bot-server)
     - [Register Slash Commands](#register-slash-commands)
     - [Run the bot](#run-the-bot)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Go to https://discordapi.com/permissions.html#378091424832 and paste in your bot
 
 ### Important Note for Windows Users
 
-If you're on Windows, `npm` scripts will not working unless you tell `npm` to use Git Bash as its default shell when running commands.
+If you're on Windows, `npm` scripts will not work unless you tell `npm` to use Git Bash as its default shell when running commands.
 
 Before continuing, run this command:
 


### PR DESCRIPTION
(Will resolve Issue #34)

On Windows, Prettier was throwing errors because it expected Unix-style line endings. Now VS Code and Prettier should accept the default line endings of whatever operating system the project is on.

On Windows, `npm` scripts would fail because the Windows terminal did not accept Linux commands or file directories. Now VS Code should default to using Git Bash for the terminal, and a note was added to the README for Windows users to set `npm`'s default script shell to Git Bash.

And on a side note, I also added a setting to tell VS Code to auto-format files on save.