### PR TITLE
Logger abstraction

### DIFF
--- a/src/@types/CommandContext.d.ts
+++ b/src/@types/CommandContext.d.ts
@@ -24,9 +24,6 @@ declare global {
 		/** Our own signed-in Discord client. */
 		readonly client: Client<true>;
 
-		/** The place to submit informative debug messages. */
-		readonly logger: Console; // TODO: More extensible logger than `console`?
-
 		/** The guild in which the command was invoked. */
 		readonly guild: Guild | null;
 

--- a/src/commandContext/followUp.test.ts
+++ b/src/commandContext/followUp.test.ts
@@ -4,17 +4,22 @@ jest.mock('../helpers/actions/messages/replyToMessage');
 import { sendMessageInChannel } from '../helpers/actions/messages/replyToMessage';
 const mockSendMessageInChannel = sendMessageInChannel as jest.Mock;
 
+jest.mock('../logger');
+import { getLogger } from '../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleError = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		error: mockConsoleError,
+	} as unknown as Console;
+});
+
 import { followUpFactory as factory } from './followUp';
 
 describe('follow-up message', () => {
 	const testMessage = { id: 'test-message' };
 	mockSendMessageInChannel.mockResolvedValue(testMessage);
 	const mockInteractionFollowUp = jest.fn().mockResolvedValue(testMessage);
-	const mockConsoleError = jest.fn();
-
-	const mockConsole = {
-		error: mockConsoleError,
-	} as unknown as Console;
 
 	const interaction = {
 		channel: {
@@ -24,7 +29,7 @@ describe('follow-up message', () => {
 		followUp: mockInteractionFollowUp,
 	} as unknown as CommandInteraction;
 
-	const followUp = factory(interaction, mockConsole);
+	const followUp = factory(interaction);
 
 	test('sends a followup message to the interaction', async () => {
 		await expect(followUp('yo')).resolves.toBe(testMessage);

--- a/src/commandContext/followUp.ts
+++ b/src/commandContext/followUp.ts
@@ -1,10 +1,10 @@
 import type { CommandInteraction, InteractionReplyOptions } from 'discord.js';
 import { sendMessageInChannel } from '../helpers/actions/messages/replyToMessage';
 
-export function followUpFactory(
-	interaction: CommandInteraction,
-	logger: Console
-): CommandContext['followUp'] {
+import { getLogger } from '../logger';
+const logger = getLogger();
+
+export function followUpFactory(interaction: CommandInteraction): CommandContext['followUp'] {
 	return async function followUp(options) {
 		if (
 			typeof options !== 'string' &&

--- a/src/commandContext/prepareForLongRunningTasks.test.ts
+++ b/src/commandContext/prepareForLongRunningTasks.test.ts
@@ -1,19 +1,25 @@
 import type { CommandInteraction } from 'discord.js';
+
+jest.mock('../logger');
+import { getLogger } from '../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleError = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		error: mockConsoleError,
+	} as unknown as Console;
+});
+
 import { prepareForLongRunningTasksFactory as factory } from './prepareForLongRunningTasks';
 
 describe('prepareForLongRunningTasks', () => {
 	const mockInteractionDeferReply = jest.fn();
-	const mockConsoleError = jest.fn();
-
-	const mockConsole = {
-		error: mockConsoleError,
-	} as unknown as Console;
 
 	const interaction = {
 		deferReply: mockInteractionDeferReply,
 	} as unknown as CommandInteraction;
 
-	const prepareForLongRunningTasks = factory(interaction, mockConsole);
+	const prepareForLongRunningTasks = factory(interaction);
 
 	test('requests interaction deferrment', async () => {
 		await expect(prepareForLongRunningTasks()).resolves.toBeUndefined();

--- a/src/commandContext/prepareForLongRunningTasks.ts
+++ b/src/commandContext/prepareForLongRunningTasks.ts
@@ -1,8 +1,10 @@
 import type { CommandInteraction } from 'discord.js';
 
+import { getLogger } from '../logger';
+const logger = getLogger();
+
 export function prepareForLongRunningTasksFactory(
-	interaction: CommandInteraction,
-	logger: Console
+	interaction: CommandInteraction
 ): CommandContext['prepareForLongRunningTasks'] {
 	return async function prepareForLongRunningTasks(ephemeral) {
 		try {

--- a/src/commandContext/reply.test.ts
+++ b/src/commandContext/reply.test.ts
@@ -1,22 +1,28 @@
 import type { CommandInteraction } from 'discord.js';
+
+jest.mock('../logger');
+import { getLogger } from '../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleInfo = jest.fn();
+const mockConsoleError = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		info: mockConsoleInfo,
+		error: mockConsoleError,
+	} as unknown as Console;
+});
+
 import { replyFactory as factory } from './reply';
 
 describe('public reply', () => {
 	const mockInteractionReply = jest.fn();
-	const mockConsoleInfo = jest.fn();
-	const mockConsoleError = jest.fn();
-
-	const mockConsole = {
-		info: mockConsoleInfo,
-		error: mockConsoleError,
-	} as unknown as Console;
 
 	const interaction = {
 		user: { id: 'user-id-1234' },
 		reply: mockInteractionReply,
 	} as unknown as CommandInteraction;
 
-	const reply = factory(interaction, mockConsole);
+	const reply = factory(interaction);
 
 	test('sends public reply to interaction with text', async () => {
 		await expect(reply('yo')).resolves.toBeUndefined();

--- a/src/commandContext/reply.ts
+++ b/src/commandContext/reply.ts
@@ -1,10 +1,10 @@
 import type { CommandInteraction, InteractionReplyOptions } from 'discord.js';
 import { logUser } from '../helpers/logUser';
 
-export function replyFactory(
-	interaction: CommandInteraction,
-	logger: Console
-): CommandContext['reply'] {
+import { getLogger } from '../logger';
+const logger = getLogger();
+
+export function replyFactory(interaction: CommandInteraction): CommandContext['reply'] {
 	return async function reply(options) {
 		let didFailToReply = false;
 

--- a/src/commandContext/replyPrivately.test.ts
+++ b/src/commandContext/replyPrivately.test.ts
@@ -4,6 +4,18 @@ jest.mock('../helpers/actions/messages/replyToMessage');
 import { replyWithPrivateMessage } from '../helpers/actions/messages/replyToMessage';
 const mockSendDM = replyWithPrivateMessage as jest.Mock;
 
+jest.mock('../logger');
+import { getLogger } from '../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleInfo = jest.fn();
+const mockConsoleError = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		info: mockConsoleInfo,
+		error: mockConsoleError,
+	} as unknown as Console;
+});
+
 import { replyPrivatelyFactory as factory } from './replyPrivately';
 
 describe('ephemeral and DM replies', () => {
@@ -11,13 +23,6 @@ describe('ephemeral and DM replies', () => {
 	const mockInteractionReply = jest.fn();
 	const mockInteractionEditReply = jest.fn();
 	const mockInteractionFollowUp = jest.fn();
-	const mockConsoleInfo = jest.fn();
-	const mockConsoleError = jest.fn();
-
-	const mockConsole = {
-		info: mockConsoleInfo,
-		error: mockConsoleError,
-	} as unknown as Console;
 
 	let interaction: CommandInteraction;
 	let replyPrivately: CommandContext['replyPrivately'];
@@ -31,7 +36,7 @@ describe('ephemeral and DM replies', () => {
 			followUp: mockInteractionFollowUp,
 		} as unknown as CommandInteraction;
 
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 	});
 
 	test('sends an ephemeral reply to check DMs', async () => {
@@ -70,7 +75,7 @@ describe('ephemeral and DM replies', () => {
 
 	test('edits the previous reply message if deferred, sending a DM with text', async () => {
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately('yo DMs', true)).resolves.toBeUndefined();
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
@@ -81,7 +86,7 @@ describe('ephemeral and DM replies', () => {
 
 	test('edits the previous reply message if deferred, sending a DM with object', async () => {
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately({ content: 'yo DMs' }, true)).resolves.toBeUndefined();
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
@@ -94,7 +99,7 @@ describe('ephemeral and DM replies', () => {
 		const testError = new Error('This is a test');
 		mockInteractionEditReply.mockRejectedValueOnce(testError);
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately({ content: 'yo' }, true)).resolves.toBeUndefined();
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
@@ -107,7 +112,7 @@ describe('ephemeral and DM replies', () => {
 
 	test('sends an ephemeral follow-up message to the interaction if the interaction is deferred', async () => {
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately('yo in secret')).resolves.toBeUndefined();
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
@@ -118,7 +123,7 @@ describe('ephemeral and DM replies', () => {
 
 	test('sends an ephemeral follow-up message from options to the interaction if the interaction is deferred', async () => {
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately({ content: 'yo object in secret' })).resolves.toBeUndefined();
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
@@ -131,7 +136,7 @@ describe('ephemeral and DM replies', () => {
 		const testError = new Error('This is a test');
 		mockInteractionFollowUp.mockRejectedValueOnce(testError);
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately('yo in secret')).resolves.toBeUndefined();
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
@@ -146,7 +151,7 @@ describe('ephemeral and DM replies', () => {
 		const testError = new Error('This is a test');
 		mockInteractionFollowUp.mockRejectedValueOnce(testError);
 		interaction = { ...interaction, deferred: true } as unknown as CommandInteraction;
-		replyPrivately = factory(interaction, mockConsole);
+		replyPrivately = factory(interaction);
 
 		await expect(replyPrivately({ content: 'yo object in secret' })).resolves.toBeUndefined();
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({

--- a/src/commandContext/replyPrivately.ts
+++ b/src/commandContext/replyPrivately.ts
@@ -2,9 +2,11 @@ import type { CommandInteraction } from 'discord.js';
 import { logUser } from '../helpers/logUser';
 import { replyWithPrivateMessage } from '../helpers/actions/messages/replyToMessage';
 
+import { getLogger } from '../logger';
+const logger = getLogger();
+
 export function replyPrivatelyFactory(
-	interaction: CommandInteraction,
-	logger: Console
+	interaction: CommandInteraction
 ): CommandContext['replyPrivately'] {
 	return async function replyPrivately(options, viaDM: boolean = false) {
 		if (viaDM) {

--- a/src/commandContext/sendTyping.test.ts
+++ b/src/commandContext/sendTyping.test.ts
@@ -1,13 +1,19 @@
 import type { CommandInteraction } from 'discord.js';
+
+jest.mock('../logger');
+import { getLogger } from '../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleDebug = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		debug: mockConsoleDebug,
+	} as unknown as Console;
+});
+
 import { sendTypingFactory as factory } from './sendTyping';
 
 describe('typing indicator', () => {
 	const mockSendTyping = jest.fn();
-	const mockConsoleDebug = jest.fn();
-
-	const mockConsole = {
-		debug: mockConsoleDebug,
-	} as unknown as Console;
 
 	const interaction = {
 		channel: {
@@ -15,7 +21,7 @@ describe('typing indicator', () => {
 		},
 	} as unknown as CommandInteraction;
 
-	const sendTyping = factory(interaction, mockConsole);
+	const sendTyping = factory(interaction);
 
 	test('sends typing indicator', () => {
 		expect(sendTyping()).toBeUndefined();

--- a/src/commandContext/sendTyping.ts
+++ b/src/commandContext/sendTyping.ts
@@ -1,9 +1,9 @@
 import type { CommandInteraction } from 'discord.js';
 
-export function sendTypingFactory(
-	interaction: CommandInteraction,
-	logger: Console
-): CommandContext['sendTyping'] {
+import { getLogger } from '../logger';
+const logger = getLogger();
+
+export function sendTypingFactory(interaction: CommandInteraction): CommandContext['sendTyping'] {
 	return function sendTyping() {
 		void interaction.channel?.sendTyping();
 		logger.debug(`Typing in channel ${interaction.channel?.id ?? 'undefined'}`);

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -1,6 +1,9 @@
 import { ApplicationCommandOptionType, EmbedBuilder } from 'discord.js';
 import axios from 'axios';
 
+import { getLogger } from '../logger';
+const logger = getLogger();
+
 interface GetComicResponse {
 	month: string;
 	num: number;
@@ -39,8 +42,8 @@ async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 		if (status !== 200) throw new Error(`${status}`);
 		return data;
 	} catch (error_) {
-		console.log('Error in getting an XKCD comic:');
-		console.log(error_);
+		logger.error('Error in getting an XKCD comic:');
+		logger.error(error_);
 		const error: GetComicResponse = {
 			month: '',
 			num: -1,

--- a/src/handleInteraction.test.ts
+++ b/src/handleInteraction.test.ts
@@ -1,8 +1,19 @@
 import type { CommandInteraction } from 'discord.js';
 import { ChannelType } from 'discord.js';
 
-const mockAllCommands = new Map<string, Command>();
+jest.mock('./logger');
+import { getLogger } from './logger';
+const mockGetLogger = getLogger as jest.Mock;
+mockGetLogger.mockImplementation(() => {
+	return {
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined,
+	} as unknown as Console;
+});
 
+const mockAllCommands = new Map<string, Command>();
 jest.mock('./commands', () => ({
 	allCommands: mockAllCommands,
 }));
@@ -13,12 +24,6 @@ describe('Command event handler', () => {
 	const selfUid = 'self-1234';
 	const otherUid = 'other-1234';
 	const channelId = 'the-channel-1234';
-	const mockConsole = {
-		debug: () => undefined,
-		info: () => undefined,
-		warn: () => undefined,
-		error: () => undefined,
-	} as unknown as Console;
 
 	test('does nothing if the sender is a bot', async () => {
 		const mockExecute = jest.fn();
@@ -48,7 +53,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.DM },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).not.toHaveBeenCalled();
 	});
 
@@ -80,7 +85,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.DM },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).not.toHaveBeenCalled();
 	});
 
@@ -112,7 +117,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.DM },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).not.toHaveBeenCalled();
 	});
 
@@ -144,7 +149,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.GuildText },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).toHaveBeenCalledOnce();
 	});
 
@@ -176,7 +181,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.DM },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).toHaveBeenCalledOnce();
 	});
 
@@ -208,7 +213,7 @@ describe('Command event handler', () => {
 			channel: { type: ChannelType.GuildText },
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).toHaveBeenCalledOnce();
 	});
 
@@ -244,7 +249,7 @@ describe('Command event handler', () => {
 			reply: mockInteractionReply,
 		} as unknown as CommandInteraction;
 
-		await expect(handleInteraction(interaction, mockConsole)).resolves.toBeUndefined();
+		await expect(handleInteraction(interaction)).resolves.toBeUndefined();
 		expect(mockExecute).not.toHaveBeenCalled();
 		expect(mockInteractionReply).toHaveBeenCalledOnce();
 		expect(mockInteractionReply).toHaveBeenCalledWith({

--- a/src/handleInteraction.ts
+++ b/src/handleInteraction.ts
@@ -24,8 +24,6 @@ const logger = getLogger();
  * The goal is for us devs to not have to worry about how exactly
  * things get done when we're writing command handlers, only
  * that what we say goes.
- *
- * @param logger The place to write system messages.
  */
 export async function handleInteraction(interaction: CommandInteraction): Promise<void> {
 	// Don't respond to bots or ourselves
@@ -75,12 +73,11 @@ export async function handleInteraction(interaction: CommandInteraction): Promis
 		client: interaction.client,
 		interaction,
 		options: interaction.options.data,
-		logger,
-		prepareForLongRunningTasks: prepareForLongRunningTasksFactory(interaction, logger),
-		replyPrivately: replyPrivatelyFactory(interaction, logger),
-		reply: replyFactory(interaction, logger),
-		followUp: followUpFactory(interaction, logger),
-		sendTyping: sendTypingFactory(interaction, logger),
+		prepareForLongRunningTasks: prepareForLongRunningTasksFactory(interaction),
+		replyPrivately: replyPrivatelyFactory(interaction),
+		reply: replyFactory(interaction),
+		followUp: followUpFactory(interaction),
+		sendTyping: sendTypingFactory(interaction),
 	};
 
 	let context: CommandContext;

--- a/src/handleInteraction.ts
+++ b/src/handleInteraction.ts
@@ -8,6 +8,9 @@ import { replyFactory } from './commandContext/reply';
 import { replyPrivatelyFactory } from './commandContext/replyPrivately';
 import { sendTypingFactory } from './commandContext/sendTyping';
 
+import { getLogger } from './logger';
+const logger = getLogger();
+
 /**
  * Performs actions from a Discord command interaction.
  * The command is ignored if the interaction is from a bot.
@@ -24,10 +27,7 @@ import { sendTypingFactory } from './commandContext/sendTyping';
  *
  * @param logger The place to write system messages.
  */
-export async function handleInteraction(
-	interaction: CommandInteraction,
-	logger: Console
-): Promise<void> {
+export async function handleInteraction(interaction: CommandInteraction): Promise<void> {
 	// Don't respond to bots or ourselves
 	if (interaction.user.bot) return;
 	if (interaction.user.id === interaction.client.user.id) return;

--- a/src/helpers/actions/deployCommands.ts
+++ b/src/helpers/actions/deployCommands.ts
@@ -9,8 +9,11 @@ import { allCommands } from '../../commands';
 import { isNonEmptyArray } from '../guards/isNonEmptyArray';
 import { revokeCommands } from './revokeCommands';
 
-export async function deployCommands(client: Client<true>, logger: Console): Promise<void> {
-	await revokeCommands(client, logger); // fresh start!
+import { getLogger } from '../../logger';
+const logger = getLogger();
+
+export async function deployCommands(client: Client<true>): Promise<void> {
+	await revokeCommands(client); // fresh start!
 
 	logger.info('Deploying commands...');
 	const commands: Array<Command> = Array.from(allCommands.values());
@@ -28,10 +31,10 @@ export async function deployCommands(client: Client<true>, logger: Console): Pro
 	}
 
 	if (isNonEmptyArray(globalCommands)) {
-		await prepareGlobalCommands(globalCommands, client, logger);
+		await prepareGlobalCommands(globalCommands, client);
 	}
 	if (isNonEmptyArray(guildCommands)) {
-		await prepareGuildedCommands(guildCommands, client, logger);
+		await prepareGuildedCommands(guildCommands, client);
 	}
 
 	logger.info(
@@ -41,8 +44,7 @@ export async function deployCommands(client: Client<true>, logger: Console): Pro
 
 async function prepareGlobalCommands(
 	globalCommands: NonEmptyArray<GlobalCommand>,
-	client: Client<true>,
-	logger: Console
+	client: Client<true>
 ): Promise<void> {
 	logger.info(
 		`${globalCommands.length} command(s) will be set globally: ${JSON.stringify(
@@ -60,8 +62,7 @@ async function prepareGlobalCommands(
 
 async function prepareGuildedCommands(
 	guildCommands: NonEmptyArray<GuildedCommand>,
-	client: Client<true>,
-	logger: Console
+	client: Client<true>
 ): Promise<void> {
 	logger.info(
 		`${guildCommands.length} command(s) require a guild: ${JSON.stringify(
@@ -70,13 +71,12 @@ async function prepareGuildedCommands(
 	);
 	const oAuthGuilds = await client.guilds.fetch();
 	const guilds = await Promise.all(oAuthGuilds.map(g => g.fetch()));
-	await Promise.all(guilds.map(guild => prepareCommandsForGuild(guild, guildCommands, logger)));
+	await Promise.all(guilds.map(guild => prepareCommandsForGuild(guild, guildCommands)));
 }
 
 async function prepareCommandsForGuild(
 	guild: Guild,
-	guildCommands: Array<GuildedCommand>,
-	logger: Console
+	guildCommands: Array<GuildedCommand>
 ): Promise<void> {
 	logger.info(`Deploying ${guildCommands.length} guild-bound command(s):`);
 

--- a/src/helpers/actions/messages/replyToMessage.test.ts
+++ b/src/helpers/actions/messages/replyToMessage.test.ts
@@ -1,4 +1,15 @@
 import type { CommandInteraction, Message, User } from 'discord.js';
+
+jest.mock('../../../logger');
+import { getLogger } from '../../../logger';
+const mockGetLogger = getLogger as jest.Mock;
+mockGetLogger.mockImplementation(() => {
+	return {
+		info: () => undefined,
+		error: () => undefined,
+	} as unknown as Console;
+});
+
 import { replyWithPrivateMessage } from './replyToMessage';
 
 describe('Message replies', () => {
@@ -25,15 +36,11 @@ describe('Message replies', () => {
 		});
 
 		test('returns false when an ephemeral reply with text fails', async () => {
-			jest.spyOn(global.console, 'error').mockImplementation(() => undefined);
-
-			mockReply.mockRejectedValueOnce(new Error('This ia a test'));
+			mockReply.mockRejectedValueOnce(new Error('This is a test'));
 			const content = 'yo';
 			await expect(replyWithPrivateMessage(interaction, content, false)).resolves.toBeFalse();
 			expect(mockReply).toHaveBeenCalledOnce();
 			expect(mockReply).toHaveBeenCalledWith({ content, ephemeral: true });
-
-			jest.restoreAllMocks();
 		});
 
 		test('sends an ephemeral reply with options', async () => {
@@ -44,15 +51,11 @@ describe('Message replies', () => {
 		});
 
 		test('returns false when an ephemeral reply with options fails', async () => {
-			jest.spyOn(global.console, 'error').mockImplementation(() => undefined);
-
-			mockReply.mockRejectedValueOnce(new Error('This ia a test'));
+			mockReply.mockRejectedValueOnce(new Error('This is a test'));
 			const content = 'yo';
 			await expect(replyWithPrivateMessage(interaction, { content }, false)).resolves.toBeFalse();
 			expect(mockReply).toHaveBeenCalledOnce();
 			expect(mockReply).toHaveBeenCalledWith({ content, ephemeral: true });
-
-			jest.restoreAllMocks();
 		});
 	});
 
@@ -112,8 +115,6 @@ describe('Message replies', () => {
 		});
 
 		test('informs the user when DMs failed', async () => {
-			jest.spyOn(global.console, 'error').mockImplementation(() => undefined);
-
 			mockUserSend.mockRejectedValueOnce(new Error('This is a test'));
 			const content = 'yo';
 			await expect(replyWithPrivateMessage(message, content, true)).resolves.toBeFalse();
@@ -124,8 +125,6 @@ describe('Message replies', () => {
 			);
 			expect(mockChannelSend).toHaveBeenCalledOnce();
 			expect(mockChannelSend).toHaveBeenCalledWith(expect.stringContaining('tried to DM you'));
-
-			jest.restoreAllMocks();
 		});
 	});
 });

--- a/src/helpers/actions/messages/replyToMessage.ts
+++ b/src/helpers/actions/messages/replyToMessage.ts
@@ -10,6 +10,9 @@ import type {
 import { ChannelType } from 'discord.js';
 import { logUser } from '../../logUser';
 
+import { getLogger } from '../../../logger';
+const logger = getLogger();
+
 /**
  * Attempts to send a direct message to a user.
  *
@@ -23,7 +26,7 @@ async function sendDM(user: User, content: string | MessageCreateOptions): Promi
 	try {
 		return await user.send(content);
 	} catch (error) {
-		console.error(`Failed to send direct message to user ${logUser(user)}:`, error);
+		logger.error(`Failed to send direct message to user ${logUser(user)}:`, error);
 		return null;
 	}
 }
@@ -50,7 +53,7 @@ async function sendDMReply(
 		}
 		return await sendDM(user, { ...options, content: response });
 	} catch (error) {
-		console.error(`Failed to send direct message to user ${logUser(user)}:`, error);
+		logger.error(`Failed to send direct message to user ${logUser(user)}:`, error);
 		return null;
 	}
 }
@@ -66,12 +69,10 @@ async function sendEphemeralReply(
 		} else {
 			await source.reply({ ...options, ephemeral: true });
 		}
-		console.info(
-			`Sent ephemeral reply to User ${logUser(source.user)}: ${JSON.stringify(options)}`
-		);
+		logger.info(`Sent ephemeral reply to User ${logUser(source.user)}: ${JSON.stringify(options)}`);
 		return true;
 	} catch (error) {
-		console.error('Failed to send ephemeral message:', error);
+		logger.error('Failed to send ephemeral message:', error);
 		return false;
 	}
 }
@@ -155,7 +156,7 @@ export async function sendMessageInChannel(
 	try {
 		return await channel.send(content);
 	} catch (error) {
-		console.error(`Failed to send message ${JSON.stringify(content)}:`, error);
+		logger.error(`Failed to send message ${JSON.stringify(content)}:`, error);
 		return null;
 	}
 }

--- a/src/helpers/actions/revokeCommands.test.ts
+++ b/src/helpers/actions/revokeCommands.test.ts
@@ -1,16 +1,23 @@
 import type { Client } from 'discord.js';
+
+jest.mock('../../logger');
+import { getLogger } from '../../logger';
+const mockGetLogger = getLogger as jest.Mock;
+mockGetLogger.mockImplementation(() => {
+	return {
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined,
+	} as unknown as Console;
+});
+
 import { revokeCommands } from './revokeCommands';
 
 describe('Command revocations', () => {
 	const mockApplicationCommandsSet = jest.fn();
 	const mockGuildCommandsSet = jest.fn();
 	const mockFetchOauthGuilds = jest.fn();
-	const mockConsole = {
-		debug: () => undefined,
-		info: () => undefined,
-		warn: () => undefined,
-		error: () => undefined,
-	} as unknown as Console;
 
 	const mockClient = {
 		application: {
@@ -49,12 +56,12 @@ describe('Command revocations', () => {
 	});
 
 	test('clears global commands', async () => {
-		await expect(revokeCommands(mockClient, mockConsole)).resolves.toBeUndefined();
+		await expect(revokeCommands(mockClient)).resolves.toBeUndefined();
 		expect(mockApplicationCommandsSet).toHaveBeenCalledOnce();
 	});
 
 	test('clears commands for each guild', async () => {
-		await expect(revokeCommands(mockClient, mockConsole)).resolves.toBeUndefined();
+		await expect(revokeCommands(mockClient)).resolves.toBeUndefined();
 		expect(mockGuildCommandsSet).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/helpers/actions/revokeCommands.ts
+++ b/src/helpers/actions/revokeCommands.ts
@@ -1,9 +1,12 @@
 import type { Client } from 'discord.js';
 
+import { getLogger } from '../../logger';
+const logger = getLogger();
+
 /**
  * Unregisters all command interactions globally and in each guild for this account.
  */
-export async function revokeCommands(client: Client<true>, logger: Console): Promise<void> {
+export async function revokeCommands(client: Client<true>): Promise<void> {
 	logger.info('Revoking global commands...');
 	await client.application?.commands.set([]);
 	logger.info('Revoked global commands');

--- a/src/helpers/actions/verifyCommandDeployments.test.ts
+++ b/src/helpers/actions/verifyCommandDeployments.test.ts
@@ -4,6 +4,16 @@ import { Collection } from 'discord.js';
 const mockAllCommands = new Map<string, Command>();
 jest.mock('../../commands', () => ({ allCommands: mockAllCommands }));
 
+jest.mock('../../logger');
+import { getLogger } from '../../logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleWarn = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		warn: mockConsoleWarn,
+	} as unknown as Console;
+});
+
 import { verifyCommandDeployments } from './verifyCommandDeployments';
 
 describe('Verify command deployments', () => {
@@ -36,13 +46,9 @@ describe('Verify command deployments', () => {
 			execute: () => undefined,
 		},
 	];
-	const mockConsoleWarn = jest.fn();
+
 	const mockFetchApplicationCommands = jest.fn();
 	const mockFetchGuildCommands = jest.fn();
-
-	const mockConsole = {
-		warn: mockConsoleWarn,
-	} as unknown as Console;
 
 	const mockClient = {
 		application: {
@@ -90,7 +96,7 @@ describe('Verify command deployments', () => {
 
 	describe('Guild commands', () => {
 		test('does nothing if the actual commands match expectations', async () => {
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).not.toHaveBeenCalled();
 		});
@@ -98,7 +104,7 @@ describe('Verify command deployments', () => {
 		test('logs a warning if the number of commands differs', async () => {
 			mockAllCommands.delete('arthur');
 
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).toHaveBeenCalledWith(
 				expect.stringContaining("commands in guild 'guild1' differ")
@@ -115,7 +121,7 @@ describe('Verify command deployments', () => {
 				execute: () => undefined,
 			});
 
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).toHaveBeenCalledWith(
 				expect.stringContaining("commands in guild 'guild1' differ")
@@ -128,7 +134,7 @@ describe('Verify command deployments', () => {
 
 	describe('Global commands', () => {
 		test('does nothing if the actual commands match expectations', async () => {
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).not.toHaveBeenCalled();
 		});
@@ -136,7 +142,7 @@ describe('Verify command deployments', () => {
 		test('logs a warning if the number of commands differs', async () => {
 			mockAllCommands.delete('zaphod');
 
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('commands differ'));
 			expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('Expected 1'));
@@ -151,7 +157,7 @@ describe('Verify command deployments', () => {
 				execute: () => undefined,
 			});
 
-			await expect(verifyCommandDeployments(mockClient, mockConsole)).resolves.toBeUndefined();
+			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('commands differ'));
 			expect(mockConsoleWarn).toHaveBeenCalledWith(

--- a/src/helpers/actions/verifyCommandDeployments.ts
+++ b/src/helpers/actions/verifyCommandDeployments.ts
@@ -1,16 +1,16 @@
 import type { Client, Guild } from 'discord.js';
 import { allCommands } from '../../commands';
 
+import { getLogger } from '../../logger';
+const logger = getLogger();
+
 /**
  * Verify that the deployed command list is up-to-date, and yell in the console if it's not.
  *
  * @param client The Discord.js client whose commands to validate.
  * @param logger The place to send error messages
  */
-export async function verifyCommandDeployments(
-	client: Client<true>,
-	logger: Console
-): Promise<void> {
+export async function verifyCommandDeployments(client: Client<true>): Promise<void> {
 	const globalDiff = await diffGlobalCommandDeployments(client);
 	if (globalDiff) {
 		const issue = globalDiff.issue;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 /**
- * A method that returns the default logger for this application
- * Uses a function instead of a constant to allow mocking
+ * A method that returns the default logger for this application.
+ * Uses a function instead of a constant to allow mocking.
  * @returns The default logger for this application
  */
 export function getLogger(): Console {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,8 @@
+/**
+ * A method that returns the default logger for this application
+ * Uses a function instead of a constant to allow mocking
+ * @returns The default logger for this application
+ */
+export function getLogger(): Console {
+	return console;
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -75,16 +75,24 @@ jest.mock('./helpers/actions/verifyCommandDeployments');
 import { verifyCommandDeployments } from './helpers/actions/verifyCommandDeployments';
 const mockVerifyCommandDeployments = verifyCommandDeployments as jest.Mock;
 
+jest.mock('./logger');
+import { getLogger } from './logger';
+const mockGetLogger = getLogger as jest.Mock;
+const mockConsoleError = jest.fn();
+mockGetLogger.mockImplementation(() => {
+	return {
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: mockConsoleError,
+	} as unknown as Console;
+});
+
 import { _main } from './main';
 
 describe('main', () => {
-	let mockConsoleError: jest.SpyInstance;
 
 	beforeEach(() => {
-		jest.spyOn(global.console, 'debug').mockImplementation(() => undefined);
-		jest.spyOn(global.console, 'info').mockImplementation(() => undefined);
-		mockConsoleError = jest.spyOn(global.console, 'error').mockImplementation(() => undefined);
-
 		mockConstructClient.mockReturnValue(undefined);
 		mockLogin.mockResolvedValue('TEST');
 		mockSetActivity.mockReturnValue({});

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export async function _main(): Promise<void> {
 
 		// Sanity check for commands
 		logger.info('Verifying command deployments...');
-		await verifyCommandDeployments(client, logger);
+		await verifyCommandDeployments(client);
 
 		// Register interaction listeners
 		client.on('interactionCreate', async interaction => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ import { parseArgs } from './helpers/parseArgs';
 import { revokeCommands } from './helpers/actions/revokeCommands';
 import { verifyCommandDeployments } from './helpers/actions/verifyCommandDeployments';
 
+import { getLogger } from './logger';
+const logger = getLogger();
+
 // We *could* do all of this at the top level, but then
 // none of this setup would be testable :P
 
@@ -29,36 +32,36 @@ export async function _main(): Promise<void> {
 
 	const args = parseArgs();
 
-	console.info('*Yawn* Good morning!');
+	logger.info('*Yawn* Good morning!');
 
 	client.on('ready', async client => {
-		console.info(`Starting ${client.user.username} v${appVersion}...`);
+		logger.info(`Starting ${client.user.username} v${appVersion}...`);
 
 		// If we're only here to deploy commands, do that and then exit
 		if (args.deploy) {
-			await deployCommands(client, console);
+			await deployCommands(client);
 			client.destroy();
 			return;
 		}
 
 		// If we're only here to revoke commands, do that and then exit
 		if (args.revoke) {
-			await revokeCommands(client, console);
+			await revokeCommands(client);
 			client.destroy();
 			return;
 		}
 
 		// Sanity check for commands
-		console.info('Verifying command deployments...');
-		await verifyCommandDeployments(client, console);
+		logger.info('Verifying command deployments...');
+		await verifyCommandDeployments(client, logger);
 
 		// Register interaction listeners
 		client.on('interactionCreate', async interaction => {
 			if (interaction.isCommand()) {
 				try {
-					await handleInteraction(interaction, console);
+					await handleInteraction(interaction);
 				} catch (error) {
-					console.error('Failed to handle interaction:', error);
+					logger.error('Failed to handle interaction:', error);
 				}
 			}
 		});
@@ -69,17 +72,17 @@ export async function _main(): Promise<void> {
 			name: '/help for info',
 		});
 
-		console.info('Ready!');
+		logger.info('Ready!');
 	});
 
 	client.on('error', error => {
-		console.error('Received client error:', error);
+		logger.error('Received client error:', error);
 	});
 
 	try {
 		await client.login(process.env['DISCORD_TOKEN']);
 	} catch (error) {
-		console.error('Failed to log in:', error);
+		logger.error('Failed to log in:', error);
 	}
 }
 


### PR DESCRIPTION
The logger was already partially abstracted before, but it required passing logger around through parameters in methods. This was causing problems for event handler abstraction.

Now the logger is in a separate file called `logger.ts` that contains a method that returns the logger to use (the console, for now). We use a method instead of a constant to make mocking easier for tests.

All files that used the logger before now pull the logger from `logger.ts` instead of passing through parameters. I also updated tests to reflect this fact by mocking `logger.ts`.