### PR TITLE
Made `EventHandler` generic over its `name` property

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/src/@types/EventHandler.d.ts
+++ b/src/@types/EventHandler.d.ts
@@ -4,7 +4,7 @@ declare global {
 	/**
 	 * Defines an event handler.
 	 */
-	interface EventHandler<K extends keyof ClientEvents> {
+	interface EventHandler<K extends keyof ClientEvents = keyof ClientEvents> {
 		/**
 		 * The name of the event to be handled. Must match one of
 		 * the discord.js event names defined in {@link ClientEvents}.

--- a/src/@types/EventHandler.d.ts
+++ b/src/@types/EventHandler.d.ts
@@ -6,18 +6,19 @@ declare global {
 	 */
 	interface EventHandler<K extends keyof ClientEvents> {
 		/**
-		 * The name of the event this handler is for
-		 * Must match one of the events as defined in ClientEvents
+		 * The name of the event to be handled. Must match one of
+		 * the discord.js event names defined in {@link ClientEvents}.
 		 */
 		readonly name: K;
 
 		/**
-		 * Whether this event can only fire once
+		 * Whether this handler should only execute the first time
+		 * the event occurs.
 		 */
 		readonly once: boolean;
 
 		/**
-		 * The event implementation. Receives any number of arguments, depending on the event.
+		 * A function that is called with the event's context.
 		 */
 		readonly execute: (...args: ClientEvents[K]) => Awaitable<void>;
 	}

--- a/src/@types/EventHandler.d.ts
+++ b/src/@types/EventHandler.d.ts
@@ -4,21 +4,21 @@ declare global {
 	/**
 	 * Defines an event handler.
 	 */
-	interface EventHandler {
+	interface EventHandler<K extends keyof ClientEvents> {
 		/**
 		 * The name of the event this handler is for
 		 * Must match one of the events as defined in ClientEvents
 		 */
-		name: keyof ClientEvents;
+		readonly name: K;
 
 		/**
 		 * Whether this event can only fire once
 		 */
-		once: boolean;
+		readonly once: boolean;
 
 		/**
 		 * The event implementation. Receives any number of arguments, depending on the event.
 		 */
-		execute: (...args: Array<any>) => Awaitable<void>;
+		readonly execute: (...args: ClientEvents[K]) => Awaitable<void>;
 	}
 }

--- a/src/events/error.ts
+++ b/src/events/error.ts
@@ -5,10 +5,10 @@ const logger = getLogger();
 /**
  * The event handler for Discord Client errors
  */
-export const error: EventHandler = {
+export const error: EventHandler<'error'> = {
 	name: 'error',
 	once: false,
-	execute(err: Error) {
+	execute(err) {
 		logger.error('Received client error:', err);
 	},
 };

--- a/src/events/error.ts
+++ b/src/events/error.ts
@@ -1,14 +1,14 @@
 // Internal dependencies
 import { getLogger } from '../logger';
+import { onEvent } from '../helpers/onEvent';
 const logger = getLogger();
 
 /**
  * The event handler for Discord Client errors
  */
-export const error: EventHandler<'error'> = {
-	name: 'error',
+export const error = onEvent('error', {
 	once: false,
 	execute(err) {
 		logger.error('Received client error:', err);
 	},
-};
+});

--- a/src/events/index.test.ts
+++ b/src/events/index.test.ts
@@ -35,11 +35,12 @@ import { _add, allEventHandlers, registerEventHandlers } from './index';
 
 describe('allEvents', () => {
 	test('index is not empty', () => {
-		expect(allEventHandlers.size).toBeGreaterThan(0);
+		expect(Object.keys(allEventHandlers).length).toBeGreaterThan(0);
 	});
 
 	test('fails to install another event handler with the same name', () => {
-		expect(() => _add({ name: 'error' } as unknown as EventHandler)).toThrow(TypeError);
+		const mockErrorHandler = { name: 'error' } as unknown as EventHandler<keyof ClientEvents>;
+		expect(() => _add(mockErrorHandler)).toThrow(TypeError);
 	});
 
 	test('properly registers events', () => {
@@ -51,20 +52,23 @@ describe('allEvents', () => {
 		// Be sure to clear all the auto-added event handlers first, or else they'll mess up our count.
 		// Casting a read-only list into a regular list is bad practice, but this is for testing purposes.
 		// Don't do this at home.
-		(allEventHandlers as Map<keyof ClientEvents, EventHandler>).clear();
+		for (const key of Object.keys(allEventHandlers)) {
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete allEventHandlers[key as keyof typeof allEventHandlers];
+		}
 
-		const fakeReadyEvent: EventHandler = {
+		const fakeReadyEvent: EventHandler<'ready'> = {
 			name: 'ready',
 			once: true,
 			execute: () => undefined,
 		};
-		const fakeMessageEvent: EventHandler = {
+		const fakeMessageEvent: EventHandler<'messageCreate'> = {
 			name: 'messageCreate',
 			once: false,
 			execute: () => undefined,
 		};
-		expect(_add(fakeReadyEvent)).toBeUndefined();
-		expect(_add(fakeMessageEvent)).toBeUndefined();
+		expect(_add(fakeReadyEvent as EventHandler<keyof ClientEvents>)).toBeUndefined();
+		expect(_add(fakeMessageEvent as EventHandler<keyof ClientEvents>)).toBeUndefined();
 
 		expect(registerEventHandlers(client)).toBeUndefined();
 

--- a/src/events/index.test.ts
+++ b/src/events/index.test.ts
@@ -35,7 +35,7 @@ import { _add, allEventHandlers, registerEventHandlers } from './index';
 
 describe('allEvents', () => {
 	test('index is not empty', () => {
-		expect(Object.keys(allEventHandlers).length).toBeGreaterThan(0);
+		expect(allEventHandlers.size).toBeGreaterThan(0);
 	});
 
 	test('fails to install another event handler with the same name', () => {
@@ -52,10 +52,7 @@ describe('allEvents', () => {
 		// Be sure to clear all the auto-added event handlers first, or else they'll mess up our count.
 		// Casting a read-only list into a regular list is bad practice, but this is for testing purposes.
 		// Don't do this at home.
-		for (const key of Object.keys(allEventHandlers)) {
-			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-			delete allEventHandlers[key as keyof typeof allEventHandlers];
-		}
+		(allEventHandlers as Map<string, unknown>).clear();
 
 		const fakeReadyEvent: EventHandler<'ready'> = {
 			name: 'ready',

--- a/src/events/index.test.ts
+++ b/src/events/index.test.ts
@@ -1,6 +1,3 @@
-// Dependencies
-import type { ClientEvents } from 'discord.js';
-
 // Create a mocked client to track 'on' and 'once' calls
 const mockOn = jest.fn();
 const mockOnce = jest.fn();
@@ -39,7 +36,7 @@ describe('allEvents', () => {
 	});
 
 	test('fails to install another event handler with the same name', () => {
-		const mockErrorHandler = { name: 'error' } as unknown as EventHandler<keyof ClientEvents>;
+		const mockErrorHandler = { name: 'error' } as unknown as EventHandler;
 		expect(() => _add(mockErrorHandler)).toThrow(TypeError);
 	});
 
@@ -54,18 +51,18 @@ describe('allEvents', () => {
 		// Don't do this at home.
 		(allEventHandlers as Map<string, unknown>).clear();
 
-		const fakeReadyEvent: EventHandler<'ready'> = {
+		const fakeReadyEvent: EventHandler = {
 			name: 'ready',
 			once: true,
 			execute: () => undefined,
 		};
-		const fakeMessageEvent: EventHandler<'messageCreate'> = {
+		const fakeMessageEvent: EventHandler = {
 			name: 'messageCreate',
 			once: false,
 			execute: () => undefined,
 		};
-		expect(_add(fakeReadyEvent as EventHandler<keyof ClientEvents>)).toBeUndefined();
-		expect(_add(fakeMessageEvent as EventHandler<keyof ClientEvents>)).toBeUndefined();
+		expect(_add(fakeReadyEvent)).toBeUndefined();
+		expect(_add(fakeMessageEvent)).toBeUndefined();
 
 		expect(registerEventHandlers(client)).toBeUndefined();
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -9,13 +9,16 @@ const logger = getLogger();
  * The private list of all event handlers. You can use this to edit the list within this file.
  * @private
  */
-const _allEventHandlers = new Map<keyof ClientEvents, EventHandler>();
+const _allEventHandlers = new Map<string, EventHandler<keyof ClientEvents>>();
 
 /**
  * A read-only list of all event handlers.
  * @public
  */
-export const allEventHandlers: ReadonlyMap<keyof ClientEvents, EventHandler> = _allEventHandlers;
+export const allEventHandlers: ReadonlyMap<
+	string,
+	EventHandler<keyof ClientEvents>
+> = _allEventHandlers;
 
 /**
  * Adds an event handler to the list of all handlers.
@@ -24,8 +27,8 @@ export const allEventHandlers: ReadonlyMap<keyof ClientEvents, EventHandler> = _
  * @param eventHandler The event handler to add
  * @private
  */
-export function _add(eventHandler: EventHandler): void {
-	const name: keyof ClientEvents = eventHandler.name;
+export function _add(eventHandler: EventHandler<keyof ClientEvents>): void {
+	const name = eventHandler.name;
 
 	if (_allEventHandlers.has(name)) {
 		throw new TypeError(
@@ -42,8 +45,9 @@ export function _add(eventHandler: EventHandler): void {
  * @public
  */
 export function registerEventHandlers(client: Client): void {
-	_allEventHandlers.forEach((eventHandler: EventHandler, eventName: keyof ClientEvents) => {
+	_allEventHandlers.forEach(eventHandler => {
 		// Register the event handler with the correct endpoint
+		const eventName = eventHandler.name;
 		if (eventHandler.once) {
 			client.once(eventName, eventHandler.execute);
 		} else {
@@ -58,6 +62,8 @@ export function registerEventHandlers(client: Client): void {
 import { error } from './error';
 import { interactionCreate } from './interactionCreate';
 import { ready } from './ready';
-_add(error);
-_add(interactionCreate);
-_add(ready);
+
+_add(error as EventHandler<keyof ClientEvents>);
+_add(interactionCreate as EventHandler<keyof ClientEvents>);
+_add(ready as EventHandler<keyof ClientEvents>);
+// Not sure why these type casts are necessary, but they seem sound. We can remove them when TS gets smarter, or we learn what I did wrong

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import type { Client, ClientEvents } from 'discord.js';
+import type { Client } from 'discord.js';
 
 // Internal dependencies
 import { getLogger } from '../logger';
@@ -9,16 +9,13 @@ const logger = getLogger();
  * The private list of all event handlers. You can use this to edit the list within this file.
  * @private
  */
-const _allEventHandlers = new Map<string, EventHandler<keyof ClientEvents>>();
+const _allEventHandlers = new Map<string, EventHandler>();
 
 /**
  * A read-only list of all event handlers.
  * @public
  */
-export const allEventHandlers: ReadonlyMap<
-	string,
-	EventHandler<keyof ClientEvents>
-> = _allEventHandlers;
+export const allEventHandlers: ReadonlyMap<string, EventHandler> = _allEventHandlers;
 
 /**
  * Adds an event handler to the list of all handlers.
@@ -27,7 +24,7 @@ export const allEventHandlers: ReadonlyMap<
  * @param eventHandler The event handler to add
  * @private
  */
-export function _add(eventHandler: EventHandler<keyof ClientEvents>): void {
+export function _add(eventHandler: EventHandler): void {
 	const name = eventHandler.name;
 
 	if (_allEventHandlers.has(name)) {
@@ -63,7 +60,7 @@ import { error } from './error';
 import { interactionCreate } from './interactionCreate';
 import { ready } from './ready';
 
-_add(error as EventHandler<keyof ClientEvents>);
-_add(interactionCreate as EventHandler<keyof ClientEvents>);
-_add(ready as EventHandler<keyof ClientEvents>);
+_add(error as EventHandler);
+_add(interactionCreate as EventHandler);
+_add(ready as EventHandler);
 // Not sure why these type casts are necessary, but they seem sound. We can remove them when TS gets smarter, or we learn what I did wrong

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -11,13 +11,13 @@ import { replyFactory } from '../commandContext/reply';
 import { replyPrivatelyFactory } from '../commandContext/replyPrivately';
 import { sendTypingFactory } from '../commandContext/sendTyping';
 import { getLogger } from '../logger';
+import { onEvent } from '../helpers/onEvent';
 const logger = getLogger();
 
 /**
  * The event handler for Discord Interactions (usually chat commands)
  */
-export const interactionCreate: EventHandler<'interactionCreate'> = {
-	name: 'interactionCreate',
+export const interactionCreate = onEvent('interactionCreate', {
 	once: false,
 	async execute(interaction) {
 		try {
@@ -28,7 +28,7 @@ export const interactionCreate: EventHandler<'interactionCreate'> = {
 			logger.error('Failed to handle interaction:', error);
 		}
 	},
-};
+});
 
 /**
  * Performs actions from a Discord command interaction.

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,11 +1,5 @@
 // Dependencies
-import type {
-	Interaction,
-	CommandInteraction,
-	DMChannel,
-	GuildMember,
-	GuildTextBasedChannel,
-} from 'discord.js';
+import type { CommandInteraction, DMChannel, GuildMember, GuildTextBasedChannel } from 'discord.js';
 import { ChannelType } from 'discord.js';
 
 // Internal dependencies
@@ -22,10 +16,10 @@ const logger = getLogger();
 /**
  * The event handler for Discord Interactions (usually chat commands)
  */
-export const interactionCreate: EventHandler = {
+export const interactionCreate: EventHandler<'interactionCreate'> = {
 	name: 'interactionCreate',
 	once: false,
-	async execute(interaction: Interaction) {
+	async execute(interaction) {
 		try {
 			if (interaction.isCommand()) {
 				await handleInteraction(interaction);

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -14,10 +14,10 @@ const logger = getLogger();
 /**
  * The event handler for when the Discord Client is ready for action
  */
-export const ready: EventHandler = {
+export const ready: EventHandler<'ready'> = {
 	name: 'ready',
 	once: true,
-	async execute(client: Client<true>) {
+	async execute(client) {
 		logger.info(`Starting ${client.user.username} v${appVersion}...`);
 
 		const args = parseArgs();

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,7 +1,6 @@
 // Dependencies
 import type { Client, ClientPresence } from 'discord.js';
 import { ActivityType } from 'discord.js';
-import { parseArgs } from '../helpers/parseArgs';
 
 // Internal dependencies
 import { deployCommands } from '../helpers/actions/deployCommands';
@@ -9,13 +8,14 @@ import { revokeCommands } from '../helpers/actions/revokeCommands';
 import { verifyCommandDeployments } from '../helpers/actions/verifyCommandDeployments';
 import { appVersion } from '../constants/meta';
 import { getLogger } from '../logger';
+import { onEvent } from '../helpers/onEvent';
+import { parseArgs } from '../helpers/parseArgs';
 const logger = getLogger();
 
 /**
  * The event handler for when the Discord Client is ready for action
  */
-export const ready: EventHandler<'ready'> = {
-	name: 'ready',
+export const ready = onEvent('ready', {
 	once: true,
 	async execute(client) {
 		logger.info(`Starting ${client.user.username} v${appVersion}...`);
@@ -46,7 +46,7 @@ export const ready: EventHandler<'ready'> = {
 
 		logger.info('Ready!');
 	},
-};
+});
 
 function setActivity(client: Client<true>): ClientPresence {
 	// Let users know where to go for info

--- a/src/helpers/onEvent.test.ts
+++ b/src/helpers/onEvent.test.ts
@@ -1,0 +1,20 @@
+import { onEvent } from './onEvent';
+
+describe('Creating event handlers', () => {
+	// We shouldn't have to worry about testing with poorly-formatted arguments.
+	// Since this is an internal tool, not one for a public SDK, we expect
+	// TypeScript to yell at any dev silly enough to include too many or too
+	// few arguments, or arguments of the wrong type.
+
+	test('creates a proper event handler', () => {
+		const execute = (): void => undefined;
+		const handler = onEvent('ready', {
+			once: true,
+			execute,
+		});
+		expect(handler).toBeObject();
+		expect(handler).toHaveProperty('name', 'ready');
+		expect(handler).toHaveProperty('once', true);
+		expect(handler).toHaveProperty('execute', execute);
+	});
+});

--- a/src/helpers/onEvent.ts
+++ b/src/helpers/onEvent.ts
@@ -1,0 +1,12 @@
+import type { ClientEvents } from 'discord.js';
+
+export function onEvent<K extends keyof ClientEvents>(
+	name: K,
+	params: Omit<EventHandler<K>, 'name'>
+): EventHandler<K> {
+	return {
+		name,
+		once: params.once,
+		execute: params.execute,
+	};
+}


### PR DESCRIPTION
Based on a discussion in https://github.com/BYU-CS-Discord/CSBot/pull/38#discussion_r985288404

The goal here is to remove the need for us to look up the params of each event when writing new event handlers, or maintaining existing ones. This makes the syntax of registering handlers slightly more complicated, but since that code is infrequently modified, I think a few words of boilerplate aren't too bad.