### PR TITLE
Added a 'Fix Twitter Links' context menu item

### DIFF
--- a/src/@types/Command.d.ts
+++ b/src/@types/Command.d.ts
@@ -29,7 +29,7 @@ declare global {
 		 *
 		 * @param context Contextual information about the command invocation.
 		 */
-		execute: (context: CommandContext) => void | Promise<void>;
+		execute: (context: TextInputCommandContext) => void | Promise<void>;
 	}
 
 	interface GuildedCommand extends BaseCommand {
@@ -51,7 +51,8 @@ declare global {
 		execute: (context: GuildedCommandContext) => void | Promise<void>;
 	}
 
-	type Command = GlobalCommand | GuildedCommand;
+	type Command = ChatInputCommand | ContextMenuCommand;
+	type ChatInputCommand = GlobalCommand | GuildedCommand;
 
 	interface BaseSubcommand extends ApplicationCommandSubCommandData {
 		type: ApplicationCommandOptionType.Subcommand;

--- a/src/@types/CommandContext.d.ts
+++ b/src/@types/CommandContext.d.ts
@@ -2,15 +2,18 @@ import type {
 	Client,
 	CommandInteraction,
 	CommandInteractionOption,
+	ContextMenuCommandInteraction,
 	DMChannel,
 	Guild,
 	GuildMember,
 	GuildTextBasedChannel,
 	InteractionReplyOptions,
 	Message,
+	MessageContextMenuCommandInteraction,
 	MessageReplyOptions,
 	Snowflake,
 	User,
+	UserContextMenuCommandInteraction,
 } from 'discord.js';
 
 declare global {
@@ -39,11 +42,23 @@ declare global {
 		/** The guild member who invoked the command. */
 		readonly member: GuildMember | null;
 
+		/** The ID of the interaction target. Only available for context menu commands. */
+		readonly targetId: Snowflake | null;
+
+		/** The user that the interaction targets. Only available for context menu commands. */
+		readonly targetUser: User | null;
+
+		/** The guild member that the interaction targets. Only available for context menu commands. */
+		readonly targetMember: GuildMember | null;
+
+		/** The message that the interaction targets. Only available for context menu commands. */
+		readonly targetMessage: Message | null;
+
 		/** The UNIX time at which the command was invoked. */
 		readonly createdTimestamp: number;
 
-		/** The options that were given to the command. */
-		readonly options: ReadonlyArray<CommandInteractionOption<'cached'>>; // TODO: Make this a generic tuple
+		/** The options that were given to the command. Not available for context menu commands. */
+		readonly options: ReadonlyArray<CommandInteractionOption<'cached'>> | null;
 
 		/** Instructs Discord to keep interaction handles open long enough for long-running tasks to complete. */
 		prepareForLongRunningTasks: (ephemeral?: boolean) => void | Promise<void>;
@@ -108,9 +123,24 @@ declare global {
 
 		/** The channel in which the command was invoked. */
 		readonly channel: DMChannel | null;
+
+		/** The ID of the interaction target. Only available for context menu commands. */
+		readonly targetId: null;
+
+		/** The user that the interaction targets. Only available for context menu commands. */
+		readonly targetUser: null;
+
+		/** The guild member that the interaction targets. Only available for context menu commands. */
+		readonly targetMember: null;
+
+		/** The message that the interaction targets. Only available for context menu commands. */
+		readonly targetMessage: null;
+
+		/** The options that were given to the command. Not available for context menu commands. */
+		readonly options: ReadonlyArray<CommandInteractionOption<'cached'>>;
 	}
 
-	/**  Information relevant to a command invocation in a guild.*/
+	/** Information relevant to a command invocation in a guild.*/
 	interface GuildedCommandContext extends BaseCommandContext {
 		/** Where the command was invoked. */
 		readonly source: 'guild';
@@ -123,8 +153,64 @@ declare global {
 
 		/** The channel in which the command was invoked. */
 		readonly channel: GuildTextBasedChannel | null;
+
+		/** The ID of the interaction target. Only available for context menu commands. */
+		readonly targetId: null;
+
+		/** The user that the interaction targets. Only available for context menu commands. */
+		readonly targetUser: null;
+
+		/** The guild member that the interaction targets. Only available for context menu commands. */
+		readonly targetMember: null;
+
+		/** The message that the interaction targets. Only available for context menu commands. */
+		readonly targetMessage: null;
+
+		/** The options that were given to the command. Not available for context menu commands. */
+		readonly options: ReadonlyArray<CommandInteractionOption<'cached'>>;
+	}
+
+	interface BaseContextMenuCommandContext extends BaseCommandContext {
+		/** Where the command was invoked. */
+		readonly source: 'guild' | 'dm';
+
+		/** The command invocation interaction. */
+		readonly interaction: ContextMenuCommandInteraction;
+
+		/** The ID of the interaction target. Only available for context menu commands. */
+		readonly targetId: Snowflake;
+
+		/** The options that were given to the command. Not available for context menu commands. */
+		readonly options: null;
+	}
+
+	/** Information relevant to a user context menu command invocation.*/
+	interface UserContextMenuCommandContext extends BaseContextMenuCommandContext {
+		/** The command invocation interaction. */
+		readonly interaction: UserContextMenuCommandInteraction;
+
+		/** The user that the interaction targets. Only available for context menu commands. */
+		readonly targetUser: User;
+
+		/** The guild member that the interaction targets. Only available for context menu commands. */
+		readonly targetMember: GuildMember | null;
+	}
+
+	/** Information relevant to a user context menu command invocation.*/
+	interface MessageContextMenuCommandContext extends BaseContextMenuCommandContext {
+		/** The command invocation interaction. */
+		readonly interaction: MessageContextMenuCommandInteraction;
+
+		/**  The message that the interaction targets. Only available for context menu commands. */
+		readonly targetMessage: Message;
 	}
 
 	/** Information relevant to a command invocation. */
-	type CommandContext = DMCommandContext | GuildedCommandContext;
+	type CommandContext = TextInputCommandContext | ContextMenuCommandContext;
+
+	/** Information relevant to a slash-command invocation. */
+	type TextInputCommandContext = DMCommandContext | GuildedCommandContext;
+
+	/** Information relevant to a context menu command invocation. */
+	type ContextMenuCommandContext = UserContextMenuCommandContext | MessageContextMenuCommandContext;
 }

--- a/src/@types/ContextMenuCommand.d.ts
+++ b/src/@types/ContextMenuCommand.d.ts
@@ -1,0 +1,31 @@
+import type { MessageApplicationCommandData, UserApplicationCommandData } from 'discord.js';
+
+declare global {
+	interface UserContextMenuCommand extends UserApplicationCommandData {
+		/** Whether the subcommand requires a guild present to execute. */
+		requiresGuild: false; // included here to better fit with `ChatInputCommand` objects
+
+		/**
+		 * The command implementation. Receives contextual information about the
+		 * command invocation. May return a `Promise`.
+		 *
+		 * @param context Contextual information about the command invocation.
+		 */
+		execute: (context: UserContextMenuCommandContext) => void | Promise<void>;
+	}
+
+	interface MessageContextMenuCommand extends MessageApplicationCommandData {
+		/** Whether the subcommand requires a guild present to execute. */
+		requiresGuild: false; // included here to better fit with `ChatInputCommand` objects
+
+		/**
+		 * The command implementation. Receives contextual information about the
+		 * command invocation. May return a `Promise`.
+		 *
+		 * @param context Contextual information about the command invocation.
+		 */
+		execute: (context: MessageContextMenuCommandContext) => void | Promise<void>;
+	}
+
+	type ContextMenuCommand = UserContextMenuCommand | MessageContextMenuCommand;
+}

--- a/src/commands/contextMenu/vxtwitter.ts
+++ b/src/commands/contextMenu/vxtwitter.ts
@@ -1,0 +1,49 @@
+import { ApplicationCommandType } from 'discord.js';
+import { positionsOfUriInText } from '../../helpers/positionsOfUriInText';
+import { URL } from 'node:url';
+
+export const vxtwitter: MessageContextMenuCommand = {
+	name: 'Fix Twitter Links',
+	type: ApplicationCommandType.Message, // context menu command
+	requiresGuild: false,
+	async execute({ targetMessage, replyPrivately }) {
+		const content = targetMessage.content;
+
+		const urlRanges = positionsOfUriInText(content);
+		if (urlRanges === null) {
+			await replyPrivately('There were no URLs found in the message.');
+			return;
+		}
+
+		const urls: Array<URL> = [];
+		for (const { start, end } of urlRanges) {
+			try {
+				const url = new URL(content.slice(start, end));
+				const twitter = 'twitter.com';
+				const permutations = [twitter, `www.${twitter}`];
+				if (permutations.includes(url.hostname)) {
+					urls.push(url);
+				}
+			} catch {
+				continue; // Not a URL, so skip to the next one
+			}
+		}
+
+		if (urls.length === 0) {
+			await replyPrivately('There were no Twitter URLs found in the message.');
+			return;
+		}
+
+		// Print each fixed link in an ephemeral message, separated by newlines
+		await replyPrivately(
+			urls
+				.map(vxTwitter)
+				.map(url => url.href)
+				.join('\n')
+		);
+	},
+};
+
+function vxTwitter(og: URL): URL {
+	return new URL(og.pathname, 'https://vxtwitter.com');
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,6 +32,8 @@ export function _add(cmd: Command): void {
 import { help } from './help';
 import { xkcd } from './xkcd';
 import { profile } from './profile';
+import { vxtwitter } from './contextMenu/vxtwitter';
 _add(help);
 _add(xkcd);
 _add(profile);
+_add(vxtwitter);

--- a/src/helpers/actions/messages/replyToMessage.ts
+++ b/src/helpers/actions/messages/replyToMessage.ts
@@ -8,7 +8,7 @@ import type {
 	TextBasedChannel,
 	User,
 } from 'discord.js';
-import { ChannelType } from 'discord.js';
+import { ChannelType, channelMention, userMention } from 'discord.js';
 
 // Internal dependencies
 import * as logger from '../../../logger';
@@ -35,7 +35,7 @@ async function sendDM(user: User, content: string | MessageCreateOptions): Promi
 function replyMessage(source: TextBasedChannel | null, content: string | null | undefined): string {
 	let msg = '';
 	if (source && source.type !== ChannelType.DM) {
-		msg += `(Reply from <#${source.id}>)\n`;
+		msg += `(Reply from ${channelMention(source.id)})\n`;
 	}
 	msg += content ?? '';
 	return msg;
@@ -123,8 +123,9 @@ export async function replyWithPrivateMessage(
 	if (message === null) {
 		// Inform the user that we tried to DM them, but they have their DMs off
 		if ('author' in source) {
+			const authorMention = userMention(source.author.id);
 			await source.channel?.send(
-				`<@!${source.author.id}> I tried to DM you just now, but it looks like your DMs are off. :slight_frown:`
+				`${authorMention} I tried to DM you just now, but it looks like your DMs are off. :slight_frown:`
 			);
 		} else if (typeof options === 'string') {
 			return await sendEphemeralReply(source, {

--- a/src/helpers/positionsOfUriInText.test.ts
+++ b/src/helpers/positionsOfUriInText.test.ts
@@ -1,0 +1,26 @@
+import type { Range } from './positionsOfUriInText';
+import { positionsOfUriInText } from './positionsOfUriInText';
+
+describe('Identifying URIs in strings', () => {
+	test.each`
+		msg                                                            | ranges
+		${''}                                                          | ${null}
+		${'nothing'}                                                   | ${null}
+		${'still nothing'}                                             | ${null}
+		${'https://nope'}                                              | ${null}
+		${'https://yep.com'}                                           | ${[{ start: 0, end: 15 }]}
+		${'https://yep.com at the start'}                              | ${[{ start: 0, end: 15 }]}
+		${'at the end https://yep.com'}                                | ${[{ start: 11, end: 26 }]}
+		${'at the end https://yep.com there is more text'}             | ${[{ start: 11, end: 26 }]}
+		${'https://yep.com https://yep.com'}                           | ${[{ start: 0, end: 15 }, { start: 16, end: 31 }]}
+		${'https://yep.com stuff https://yep.com'}                     | ${[{ start: 0, end: 15 }, { start: 22, end: 37 }]}
+		${'starts https://yep.com and https://yep.com'}                | ${[{ start: 7, end: 22 }, { start: 27, end: 42 }]}
+		${'https://yep.com then https://yep.com ends'}                 | ${[{ start: 0, end: 15 }, { start: 21, end: 36 }]}
+		${'https://yep.com https://yep.com then https://yep.com ends'} | ${[{ start: 0, end: 15 }, { start: 16, end: 31 }, { start: 37, end: 52 }]}
+	`(
+		"correctly identifies URI substring range(s) in string '$msg'",
+		({ msg, ranges }: { msg: string; ranges: NonEmptyArray<Range> | null }) => {
+			expect(positionsOfUriInText(msg)).toStrictEqual(ranges);
+		}
+	);
+});

--- a/src/helpers/positionsOfUriInText.ts
+++ b/src/helpers/positionsOfUriInText.ts
@@ -1,0 +1,30 @@
+export interface Range {
+	start: number;
+	end: number;
+}
+
+/**
+ * Returns an array of index positions in the given string that may
+ * encapsulate URLs, or `null` if no URLs were found.
+ */
+export function positionsOfUriInText(str: string): NonEmptyArray<Range> | null {
+	const uri =
+		/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gu;
+
+	let results: NonEmptyArray<Range> | null = null;
+	let match: RegExpExecArray | null = null;
+
+	while ((match = uri.exec(str))) {
+		const range: Range = {
+			start: match.index,
+			end: match.index + (match[0]?.length ?? 0),
+		};
+		if (!results) {
+			results = [range];
+		} else {
+			results.push(range);
+		}
+	}
+
+	return results;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,7 @@
 		"noUncheckedIndexedAccess": true,
 		"typeRoots": ["./node_modules/@types", "./src"],
 		"types": ["node"],
-		"skipLibCheck": true,
+		"skipLibCheck": true, // disable this once our deps get their act together
 		"forceConsistentCasingInFileNames": true
 	}
 }


### PR DESCRIPTION
- New context menu item sends an ephemeral message with better versions of Twitter links
- Adds basic bones for context-menu commands, similar to the way chat-input (slash) commands work
- Fixed some cases of hard-coded formatting, using [Discord.js's tools](https://discordjs.guide/popular-topics/builders.html#links)

Closes #45