### PR TITLE
First go at reaction duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 - 2022-10-11
+## 0.5.0 - 2022-10-13
 ### Added
-- A message context menu command to fix Twitter links using vxtwitter
+- We now join in on the server community by sharing reactions (mostly randomly). The default :star: emoji is ignored, in the interest of future features. :same: and :no_u: emoji are reciprocated 1 in 5 times, and every other emote is reciprocated 1 in 100 times.
+
+## 0.4.0 - 2022-10-13
+### Added
+- A message context menu command to fix Twitter links using vxtwitter.
 
 ## 0.3.0 - 2022-10-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Retrieves the profile picture of the given user.
 
 ### /xkcd
 
-Retrieves the most recent [XKCD](https://xkcd.com/) comic, or the given one.
+Retrieves the most recent [xkcd](https://xkcd.com/) comic, or the given one.
 
 ## Context Menu Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.4.0",
+			"version": "0.5.0",
 			"license": "Unlicense",
 			"dependencies": {
 				"@prisma/client": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csbot",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "The One beneath the Supreme Overlord's rule. A bot to help manage the BYU CS Discord, successor to Ze Kaiser (https://github.com/arkenstorm/ze-kaiser)",
 	"private": true,
 	"scripts": {

--- a/src/constants/reactionDuplication.ts
+++ b/src/constants/reactionDuplication.ts
@@ -1,0 +1,11 @@
+// TODO: Make these configurable
+export const DEFAULT_CHANCE = 100;
+
+// The chances, where 1 is always, 100 is once every 100 times, and 0 is never.
+// We're using integers here because floating-point math is silly
+export const chances: Record<string, number> = {
+	no_u: 5,
+	nou: 5,
+	same: 5,
+	'⭐': 0, // certain default emoji are represented in the API as emoji characters, not names
+};

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -57,9 +57,11 @@ export function registerEventHandlers(client: Client): void {
 // Install event handlers
 import { error } from './error';
 import { interactionCreate } from './interactionCreate';
+import { messageReactionAdd } from './messageReactionAdd';
 import { ready } from './ready';
 
 _add(error as EventHandler);
 _add(interactionCreate as EventHandler);
+_add(messageReactionAdd as EventHandler);
 _add(ready as EventHandler);
 // Not sure why these type casts are necessary, but they seem sound. We can remove them when TS gets smarter, or we learn what I did wrong

--- a/src/events/messageReactionAdd.test.ts
+++ b/src/events/messageReactionAdd.test.ts
@@ -1,0 +1,82 @@
+import type { MessageReaction, User } from 'discord.js';
+import { messageReactionAdd } from './messageReactionAdd';
+
+describe('Reaction duplication', () => {
+	const mockResendReact = jest.fn<Promise<unknown>, []>();
+
+	let mockRandom: jest.SpyInstance<number, []>;
+	let mockReaction: MessageReaction;
+	let mockSender: User;
+
+	beforeEach(() => {
+		mockRandom = jest.spyOn(global.Math, 'random').mockReturnValue(1);
+
+		mockReaction = {
+			me: false,
+			client: {
+				user: {
+					id: 'itz-meeee',
+				},
+			},
+			message: {
+				author: {
+					id: 'other-user',
+				},
+			},
+			emoji: {
+				name: 'blue_square',
+			},
+			count: 1,
+			react: mockResendReact,
+		} as unknown as MessageReaction;
+
+		mockSender = {
+			bot: false,
+		} as unknown as User;
+	});
+
+	afterEach(() => {
+		mockRandom.mockRestore();
+	});
+
+	test("sometimes duplicates a user's react", async () => {
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).toHaveBeenCalledOnce();
+	});
+
+	test("sometimes ignores a user's react", async () => {
+		mockRandom.mockReturnValue(0.5);
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+
+	test('ignores emoji with an empty name', async () => {
+		mockReaction.emoji.name = '';
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+
+	test('ignores emoji with a null name', async () => {
+		mockReaction.emoji.name = null;
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+
+	test('ignores bot reacts', async () => {
+		mockSender.bot = true;
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+
+	test("ignores the bot's own reacts", async () => {
+		mockReaction.me = true;
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+
+	test('ignores :star:', async () => {
+		mockReaction.emoji.name = '⭐';
+		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		expect(mockResendReact).not.toHaveBeenCalled();
+	});
+});

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -1,0 +1,52 @@
+import * as logger from '../logger';
+import { onEvent } from '../helpers/onEvent';
+
+/**
+ * The event handler for emoji reactions.
+ */
+export const messageReactionAdd = onEvent('messageReactionAdd', {
+	once: false,
+	async execute(reaction, user) {
+		const ogEmojiName = reaction.emoji.name ?? '';
+		const emojiName = ogEmojiName.toLowerCase();
+
+		// Ignore nameless emoji. Not sure what those are about
+		if (!emojiName) return;
+
+		if (
+			user.bot ||
+			user.id === reaction.client.user.id ||
+			reaction.me || // never self-react
+			reaction.message.author === reaction.client.user ||
+			(reaction.count ?? 0) > 1 // never join the bandwagon
+		) {
+			return;
+		}
+
+		// The chances, where 1 is always, 100 is once every 100 times, and 0 is never.
+		// We're using integers here because floating-point math is silly
+		const DEFAULT_CHANCE = 100;
+		const odds: Record<string, number> = {
+			// TODO: Make these configurable
+			no_u: 5,
+			nou: 5,
+			same: 5,
+			'⭐': 0,
+		};
+		const random = Math.round(Math.random() * 100);
+		const chance = odds[emojiName] ?? DEFAULT_CHANCE;
+
+		if (chance === 0) {
+			logger.debug(`There is no chance I'd react to :${ogEmojiName}:`);
+			return;
+		}
+
+		logger.debug(`There is a 1-in-${chance} chance that I'd react to :${ogEmojiName}:`);
+		if (random % chance === 0) {
+			logger.debug('I did.');
+			await reaction.react();
+		} else {
+			logger.debug('I did not.');
+		}
+	},
+});

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -14,10 +14,9 @@ export const messageReactionAdd = onEvent('messageReactionAdd', {
 		if (!emojiName) return;
 
 		if (
-			user.bot ||
-			user.id === reaction.client.user.id ||
-			reaction.me || // never self-react
-			reaction.message.author === reaction.client.user ||
+			user.bot || // ignore bots
+			reaction.me || // ignore own reacts
+			reaction.message.author?.id === reaction.client.user.id || // never self-react
 			(reaction.count ?? 0) > 1 // never join the bandwagon
 		) {
 			return;
@@ -31,7 +30,7 @@ export const messageReactionAdd = onEvent('messageReactionAdd', {
 			no_u: 5,
 			nou: 5,
 			same: 5,
-			'⭐': 0,
+			'⭐': 0, // certain default emoji are represented in the API as emoji characters, not names
 		};
 		const random = Math.round(Math.random() * 100);
 		const chance = odds[emojiName] ?? DEFAULT_CHANCE;

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -1,4 +1,5 @@
 import * as logger from '../logger';
+import { chances, DEFAULT_CHANCE } from '../constants/reactionDuplication';
 import { onEvent } from '../helpers/onEvent';
 
 /**
@@ -22,18 +23,8 @@ export const messageReactionAdd = onEvent('messageReactionAdd', {
 			return;
 		}
 
-		// The chances, where 1 is always, 100 is once every 100 times, and 0 is never.
-		// We're using integers here because floating-point math is silly
-		const DEFAULT_CHANCE = 100;
-		const odds: Record<string, number> = {
-			// TODO: Make these configurable
-			no_u: 5,
-			nou: 5,
-			same: 5,
-			'⭐': 0, // certain default emoji are represented in the API as emoji characters, not names
-		};
-		const random = Math.round(Math.random() * 100);
-		const chance = odds[emojiName] ?? DEFAULT_CHANCE;
+		// The chances, where 1 is always, 100 is once every 100 times, and 0 is never
+		const chance = chances[emojiName] ?? DEFAULT_CHANCE;
 
 		if (chance === 0) {
 			logger.debug(`There is no chance I'd react to :${ogEmojiName}:`);
@@ -41,6 +32,7 @@ export const messageReactionAdd = onEvent('messageReactionAdd', {
 		}
 
 		logger.debug(`There is a 1-in-${chance} chance that I'd react to :${ogEmojiName}:`);
+		const random = Math.round(Math.random() * 100);
 		if (random % chance === 0) {
 			logger.debug('I did.');
 			await reaction.react();

--- a/src/helpers/actions/messages/replyToMessage.test.ts
+++ b/src/helpers/actions/messages/replyToMessage.test.ts
@@ -7,16 +7,22 @@ import { error as mockLoggerError } from '../../../logger';
 import { replyWithPrivateMessage, sendMessageInChannel } from './replyToMessage';
 
 describe('Replies', () => {
-	const mockUserSend = jest.fn().mockResolvedValue({});
+	const mockUserSend = jest.fn();
 
 	describe('to interactions', () => {
 		const mockReply = jest.fn();
 		let interaction: CommandInteraction;
 
 		beforeEach(() => {
+			mockReply.mockResolvedValue({});
+			mockUserSend.mockResolvedValue({});
 			interaction = {
 				user: {
 					id: 'user-1234',
+					send: mockUserSend,
+				},
+				channel: {
+					id: 'channel-1234',
 				},
 				reply: mockReply,
 			} as unknown as CommandInteraction;
@@ -50,6 +56,58 @@ describe('Replies', () => {
 			await expect(replyWithPrivateMessage(interaction, { content }, false)).resolves.toBeFalse();
 			expect(mockReply).toHaveBeenCalledOnce();
 			expect(mockReply).toHaveBeenCalledWith({ content, ephemeral: true });
+		});
+
+		describe('in DMs', () => {
+			test('sends text DM to user with return prompt', async () => {
+				const content = 'yo';
+				await expect(replyWithPrivateMessage(interaction, content, true)).resolves.toBeObject();
+				expect(mockReply).not.toHaveBeenCalled();
+				expect(mockUserSend).toHaveBeenCalledOnce();
+				expect(mockUserSend).toHaveBeenCalledWith(`(Reply from <#channel-1234>)\n${content}`);
+			});
+
+			test('sends object DM to user with return prompt', async () => {
+				const options = { content: 'yo' };
+				await expect(replyWithPrivateMessage(interaction, options, true)).resolves.toBeObject();
+				expect(mockReply).not.toHaveBeenCalled();
+				expect(mockUserSend).toHaveBeenCalledOnce();
+				expect(mockUserSend).toHaveBeenCalledWith({
+					content: `(Reply from <#channel-1234>)\n${options.content}`,
+				});
+			});
+
+			test('informs the user if the text DM failed', async () => {
+				const error = new Error('This is a test');
+				mockUserSend.mockRejectedValueOnce(error);
+
+				const content = 'yo';
+				await expect(replyWithPrivateMessage(interaction, content, true)).resolves.toBeTrue();
+				expect(mockUserSend).toHaveBeenCalledOnce();
+				expect(mockUserSend).toHaveBeenCalledWith(`(Reply from <#channel-1234>)\n${content}`);
+				expect(mockReply).toHaveBeenCalledOnce();
+				expect(mockReply).toHaveBeenCalledWith({
+					content: expect.stringContaining('tried to DM you') as string,
+					ephemeral: true,
+				});
+			});
+
+			test('informs the user if the object DM failed', async () => {
+				const error = new Error('This is a test');
+				mockUserSend.mockRejectedValueOnce(error);
+
+				const options = { content: 'yo' };
+				await expect(replyWithPrivateMessage(interaction, options, true)).resolves.toBeTrue();
+				expect(mockUserSend).toHaveBeenCalledOnce();
+				expect(mockUserSend).toHaveBeenCalledWith({
+					content: `(Reply from <#channel-1234>)\n${options.content}`,
+				});
+				expect(mockReply).toHaveBeenCalledOnce();
+				expect(mockReply).toHaveBeenCalledWith({
+					content: expect.stringContaining('tried to DM you') as string,
+					ephemeral: true,
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
New stuff:
- The bot now duplicates some initial message reactions.
  - :star: is ignored
  - 1 in 5 chance for :same: and :no_u:
  - 1 in 100 for every other emoji
  - Emoji names are case-normalized (e.g. any capitalization of :same: will do)

I anticipate we can make these odds configurable once we have the database fleshed out. We'd need at least:
- Some place to store the default reaction chance
- Some place to store the names and off-chances of each special emoji
- Some way to tie those emoji to the eventual X-board (to prevent the bot from affecting those stats) without excess database I/O

Closes #24