### PR TITLE
Hotfix - Node v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,21 +14,11 @@ jobs:
       env:
         DOCKER: true
 
-    strategy:
-      matrix:
-        node-version: [16.10.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v2
 
       - name: Own all files
         run: USER=$(/usr/bin/id -run) && chown -R $USER ./
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: node
+      image: node:16.10.0
       env:
         DOCKER: true
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:16.10.0-slim
 RUN apt update
 RUN apt upgrade --yes
 


### PR DESCRIPTION
Currently, our Docker container automatically uses the latest version of Node, which just updated to v19. This is probably unstable. It might be best to hard-lock our dev environment to v16 until we know if our dependencies support v18 LTS.

