### PR TITLE
fix: Slash commands should always receive a `ChatInputCommandInteraction`

### DIFF
--- a/src/@types/CommandContext.d.ts
+++ b/src/@types/CommandContext.d.ts
@@ -1,4 +1,5 @@
 import type {
+	ChatInputCommandInteraction,
 	Client,
 	CommandInteraction,
 	CommandInteractionOption,
@@ -115,6 +116,9 @@ declare global {
 		/** Where the command was invoked. */
 		readonly source: 'dm';
 
+		/** The command invocation interaction. */
+		readonly interaction: ChatInputCommandInteraction;
+
 		/** The guild in which the command was invoked. */
 		readonly guild: null;
 
@@ -144,6 +148,9 @@ declare global {
 	interface GuildedCommandContext extends BaseCommandContext {
 		/** Where the command was invoked. */
 		readonly source: 'guild';
+
+		/** The command invocation interaction. */
+		readonly interaction: ChatInputCommandInteraction;
 
 		/** The guild in which the command was invoked. */
 		readonly guild: Guild;

--- a/src/events/interactionCreate.test.ts
+++ b/src/events/interactionCreate.test.ts
@@ -108,6 +108,7 @@ function defaultInteraction(): Interaction {
 			partial: false,
 		},
 		isCommand: () => true,
+		isChatInputCommand: () => true,
 	} as unknown as Interaction;
 }
 
@@ -282,6 +283,7 @@ describe('on(interactionCreate)', () => {
 
 	test('fetches the member target from a partial guild member', async () => {
 		const interaction = defaultInteraction() as UserContextMenuCommandInteraction;
+		interaction.isChatInputCommand = (): boolean => false;
 		interaction.isUserContextMenuCommand = (): boolean => true;
 		interaction.inCachedGuild = (): boolean => false;
 		interaction.targetId = 'target-user-1234';
@@ -295,6 +297,7 @@ describe('on(interactionCreate)', () => {
 
 	test('executes the user context menu command', async () => {
 		const interaction = defaultInteraction() as UserContextMenuCommandInteraction;
+		interaction.isChatInputCommand = (): boolean => false;
 		interaction.isUserContextMenuCommand = (): boolean => true;
 		interaction.isMessageContextMenuCommand = (): boolean => false;
 		interaction.targetId = 'target-user-1234';
@@ -311,6 +314,7 @@ describe('on(interactionCreate)', () => {
 
 	test('executes the message context menu command', async () => {
 		const interaction = defaultInteraction() as MessageContextMenuCommandInteraction;
+		interaction.isChatInputCommand = (): boolean => false;
 		interaction.isUserContextMenuCommand = (): boolean => false;
 		interaction.isMessageContextMenuCommand = (): boolean => true;
 		interaction.targetId = 'target-msg-1234';

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -74,7 +74,7 @@ async function handleInteraction(interaction: CommandInteraction): Promise<void>
 		channel = interaction.channel;
 	}
 
-	const vagueContext: Omit<CommandContext, 'source'> = {
+	const vagueContext: Omit<CommandContext, 'source' | 'interaction'> = {
 		createdTimestamp: interaction.createdTimestamp,
 		targetId: null,
 		targetUser: null,
@@ -86,7 +86,6 @@ async function handleInteraction(interaction: CommandInteraction): Promise<void>
 		channelId: interaction.channelId,
 		channel,
 		client: interaction.client,
-		interaction,
 		options: interaction.options.data,
 		prepareForLongRunningTasks: prepareForLongRunningTasksFactory(interaction),
 		replyPrivately: replyPrivatelyFactory(interaction),
@@ -108,6 +107,10 @@ async function handleInteraction(interaction: CommandInteraction): Promise<void>
 		context = { ...vagueContext, source: 'dm' } as DMCommandContext;
 	}
 	/* eslint-enable @typescript-eslint/consistent-type-assertions */
+
+	if (interaction.isChatInputCommand()) {
+		context = { ...context, interaction };
+	}
 
 	if (!command.requiresGuild) {
 		// No guild required


### PR DESCRIPTION
Fixes an internal bug that required weird backflips or type assertions to get the right options from slash command option resolvers.