### PR TITLE
Updated version of vulnerable undici dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.7.0",
+			"version": "0.8.0",
 			"license": "Unlicense",
 			"dependencies": {
 				"@discordjs/voice": "0.13.0",
@@ -9102,9 +9102,9 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -16159,9 +16159,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"requires": {
 				"busboy": "^1.6.0"
 			}


### PR DESCRIPTION
npm reported a vulnerability in the `undici` dependency (of some other dependency). This updates the `package-lock.json` to use the patched version.