### PR TITLE
fix: Include options in call handlers

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -85,15 +85,17 @@ async function handleCommandInteraction(
 
 	let context: CommandContext;
 
+	const options = interaction.options.data;
+
 	// The following assertions assume that discord.js behaves consistently,
 	// checking the `guild` and `member` fields. See for reference
 	// https://github.com/discordjs/discord.js/blob/14.5.0/packages/discord.js/src/structures/BaseInteraction.js#L176
 
 	/* eslint-disable @typescript-eslint/consistent-type-assertions */
 	if (interaction.inGuild()) {
-		context = { ...vagueContext, source: 'guild' } as GuildedCommandContext;
+		context = { ...vagueContext, source: 'guild', options } as GuildedCommandContext;
 	} else {
-		context = { ...vagueContext, source: 'dm' } as DMCommandContext;
+		context = { ...vagueContext, source: 'dm', options } as DMCommandContext;
 	}
 	/* eslint-enable @typescript-eslint/consistent-type-assertions */
 


### PR DESCRIPTION
Fixes `/xkcd` options not working right at all not at all no.