### PR TITLE
Auto-release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -104,6 +104,16 @@
 				"prettier/prettier": "warn",
 				"max-nested-callbacks": "off" // unit tests involve a lot of nested callbacks
 			}
+		},
+		{
+			"files": ["scripts/**/*.ts"],
+			"parserOptions": {
+				"project": "./tsconfig.test.json",
+				"tsconfigRootDir": "."
+			},
+			"rules": {
+				"unicorn/no-process-exit": "off"
+			}
 		}
 	]
 }

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,35 @@
+name: Create Release
+
+# On push to main, if the latest version in CHANGELOG.md is different from the latest version tag, create a new tag and release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# This sets appropriate permissions for the default `GITHUB_TOKEN`.
+# Protected tags are incompatible with this arrangement for now.
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse Changelog
+        id: changelog
+        uses: coditory/changelog-parser@v1.0.2
+
+      - name: Publish Release
+        if: steps.changelog.outputs.status != 'unreleased'
+        # This action doesn't create a new release if the tag already exists
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.changelog.outputs.version }}
+          name: v${{ steps.changelog.outputs.version }}
+          body: ${{ steps.changelog.outputs.description }}
+          prerelease: true

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -10,13 +10,15 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    container:
-      image: node:16.19.0
-      env:
-        DOCKER: true
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -1,0 +1,25 @@
+name: Check Versions Match
+
+# On PR to main, check that package.json and package-lock.json share the version, and that CHANGELOG.md is spec-compliant. Block otherwise.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16.19.0
+      env:
+        DOCKER: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Check versions Match
+        run: npm run release

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,44 +6,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.8.3 - 2023-03-17
+
 ### Changed
+
 - Improved formatting of interaction error output.
 
 ### Fixed
+
 - Typo in interaction error output.
 
 ## 0.8.2 - 2023-03-17
+
 ### Changed
+
 - Replies from `/findroom` are now sent ephemerally.
 
 ### Fixed
+
 - Command crash when processing options for certain commands.
 
 ## 0.8.1 - 2023-03-16
+
 ### Added
+
 - Custom errors types for `/update` command.
 
 ## 0.8.0 - 2023-03-08
+
 ### Added
+
 - A new `/findroom` command for searching available rooms on campus.
 
 ## 0.7.1 - 2023-02-04
+
 ### Added
+
 - GitHub workflow stages for export-version and linting.
 - VS Code devcontainer setup.
 - README sections on testing and devcontainers.
 
 ### Changed
+
 - Updated node versioning across the project.
 - Simplified npm scripts to be more intuitive.
 - Docker is now optional.
 
 ### Fixed
+
 - Bug where replied interactions couldn't report errors.
 - Missing "git" dependency for /update command in Docker container.
 
 ## 0.7.0 - 2023-01-07
+
 ### Added
+
 - New option autocomplete feature for commands.
 - A new `/sendtag` command for testing purposes.
 - New button functionality for interactions.
@@ -51,64 +67,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new `/tothegallows` command to start a game of evil hangman.
 
 ### Changed
+
 - README organization.
 
 ## 0.6.1 - 2022-12-10
+
 ### Added
+
 - Infrastructure to handle static autocomplete options.
 
 ## 0.6.0 - 2022-12-03
+
 ### Added
+
 - A new `/talk` command has been added - uses the [dectalk](https://github.com/babakinha/dectalk) TTS engine to speak a given message.
 - A new `Talk` context menu command has been added - also uses dectalk to speak any message users right-click on.
 
 ### Changed
+
 - The error reporting system for commands has also been standardized.
 
 ## 0.5.2 - 2022-12-02
+
 ### Changed
+
 - New safety guards for the `/profile` command.
 
 ## 0.5.1 - 2022-11-29
+
 ### Changed
+
 - Use the new-and-improved [FixTweet](https://github.com/FixTweet/FixTweet) instead of ye olde [BetterTwitFix](https://github.com/dylanpdx/BetterTwitFix).
 - Our development environment is now standardized with Docker.
 
 ## 0.5.0 - 2022-10-13
+
 ### Added
+
 - We now join in on the server community by sharing reactions (mostly randomly). The default :star: emoji is ignored, in the interest of future features. :same: and :no_u: emoji are reciprocated 1 in 5 times, and every other emote is reciprocated 1 in 100 times.
 
 ## 0.4.0 - 2022-10-13
+
 ### Added
+
 - A message context menu command to fix Twitter links using vxtwitter.
 
 ## 0.3.0 - 2022-10-02
+
 ### Added
+
 - The `/profile` command now returns the profile picture for a specified user.
 
 ## 0.2.0 - 2022-10-01
+
 ### Added
+
 - Request a comic from the XKCD api with `/xkcd <number>`.
 
 ## 0.1.3 - 2022-09-30
+
 ### Added
+
 - Notice in the bot's user profile to do `/help` for bot info.
 
 ### Changed
-- The `/help` command no longer lists any commands itself. It now directs users to  try Discord's own Slash Commands UI.
+
+- The `/help` command no longer lists any commands itself. It now directs users to try Discord's own Slash Commands UI.
 - Moved the repo URL from the bot's profile (where it was largely inaccessible anyway) to the `/help` output.
 
 ## 0.1.2 - 2022-09-29
+
 ### Added
+
 - We now check the command deployments on startup. If the deployed command names differ from the known ones, that means we missed a deployment.
 
 ### Changed
+
 - Reorganized command contexts for better ergonomics and maintainability.
 
 ## 0.1.1 - 2022-09-28
+
 ### Changed
+
 - The `/help` command now lists all commands.
 
 ## 0.1.0 - 2022-09-27
+
 ### Added
+
 - Development Environment for needed dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.3 - 2023-03-17
+## [0.8.3] - 2023-03-17
 
 ### Changed
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Typo in interaction error output.
 
-## 0.8.2 - 2023-03-17
+## [0.8.2] - 2023-03-17
 
 ### Changed
 
@@ -25,19 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Command crash when processing options for certain commands.
 
-## 0.8.1 - 2023-03-16
+## [0.8.1] - 2023-03-16
 
 ### Added
 
 - Custom errors types for `/update` command.
 
-## 0.8.0 - 2023-03-08
+## [0.8.0] - 2023-03-08
 
 ### Added
 
 - A new `/findroom` command for searching available rooms on campus.
 
-## 0.7.1 - 2023-02-04
+## [0.7.1] - 2023-02-04
 
 ### Added
 
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug where replied interactions couldn't report errors.
 - Missing "git" dependency for /update command in Docker container.
 
-## 0.7.0 - 2023-01-07
+## [0.7.0] - 2023-01-07
 
 ### Added
 
@@ -70,13 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README organization.
 
-## 0.6.1 - 2022-12-10
+## [0.6.1] - 2022-12-10
 
 ### Added
 
 - Infrastructure to handle static autocomplete options.
 
-## 0.6.0 - 2022-12-03
+## [0.6.0] - 2022-12-03
 
 ### Added
 
@@ -87,44 +87,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The error reporting system for commands has also been standardized.
 
-## 0.5.2 - 2022-12-02
+## [0.5.2] - 2022-12-02
 
 ### Changed
 
 - New safety guards for the `/profile` command.
 
-## 0.5.1 - 2022-11-29
+## [0.5.1] - 2022-11-29
 
 ### Changed
 
 - Use the new-and-improved [FixTweet](https://github.com/FixTweet/FixTweet) instead of ye olde [BetterTwitFix](https://github.com/dylanpdx/BetterTwitFix).
 - Our development environment is now standardized with Docker.
 
-## 0.5.0 - 2022-10-13
+## [0.5.0] - 2022-10-13
 
 ### Added
 
 - We now join in on the server community by sharing reactions (mostly randomly). The default :star: emoji is ignored, in the interest of future features. :same: and :no_u: emoji are reciprocated 1 in 5 times, and every other emote is reciprocated 1 in 100 times.
 
-## 0.4.0 - 2022-10-13
+## [0.4.0] - 2022-10-13
 
 ### Added
 
 - A message context menu command to fix Twitter links using vxtwitter.
 
-## 0.3.0 - 2022-10-02
+## [0.3.0] - 2022-10-02
 
 ### Added
 
 - The `/profile` command now returns the profile picture for a specified user.
 
-## 0.2.0 - 2022-10-01
+## [0.2.0] - 2022-10-01
 
 ### Added
 
 - Request a comic from the XKCD api with `/xkcd <number>`.
 
-## 0.1.3 - 2022-09-30
+## [0.1.3] - 2022-09-30
 
 ### Added
 
@@ -135,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `/help` command no longer lists any commands itself. It now directs users to try Discord's own Slash Commands UI.
 - Moved the repo URL from the bot's profile (where it was largely inaccessible anyway) to the `/help` output.
 
-## 0.1.2 - 2022-09-29
+## [0.1.2] - 2022-09-29
 
 ### Added
 
@@ -145,14 +145,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reorganized command contexts for better ergonomics and maintainability.
 
-## 0.1.1 - 2022-09-28
+## [0.1.1] - 2022-09-28
 
 ### Changed
 
 - The `/help` command now lists all commands.
 
-## 0.1.0 - 2022-09-27
+## [0.1.0] - 2022-09-27
 
 ### Added
 
 - Development Environment for needed dependencies.
+
+[0.8.3]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.8.2...v0.8.3
+[0.8.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.1.3...v0.2.0
+[0.1.3]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/BYU-CS-Discord/CSBot/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,11 +45,15 @@
 				"jest": "28.1.3",
 				"jest-environment-node": "28.1.3",
 				"jest-extended": "3.1.0",
+				"keep-a-changelog": "2.2.1",
 				"nodemon": "2.0.20",
 				"prettier": "2.7.1",
 				"prettier-plugin-prisma": "4.4.0",
 				"prisma": "4.3.1",
+				"semver": "7.3.8",
+				"superstruct": "1.0.3",
 				"ts-jest": "28.0.8",
+				"ts-node": "10.9.1",
 				"typescript": "4.8.3"
 			},
 			"engines": {
@@ -645,6 +649,44 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@deno/shim-deno": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.12.0.tgz",
+			"integrity": "sha512-nD/Izdp4RfU35rip2Jx4lP1WOWY8qAvGLpB3wvjlwgut237/RS4PwhLdmYnxDBXdsjjWMx8sDxmdHWs35GF3yA==",
+			"dev": true,
+			"dependencies": {
+				"@deno/shim-deno-test": "^0.4.0",
+				"which": "^2.0.2"
+			}
+		},
+		"node_modules/@deno/shim-deno-test": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.4.0.tgz",
+			"integrity": "sha512-oYWcD7CpERZy/TXMTM9Tgh1HD/POHlbY9WpzmAk+5H8DohcxG415Qws8yLGlim3EaKBT2v3lJv01x4G0BosnaQ==",
 			"dev": true
 		},
 		"node_modules/@derhuerst/http-basic": {
@@ -2022,6 +2064,30 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+			"dev": true
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.1.20",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
@@ -2637,6 +2703,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3249,6 +3321,12 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
 		"node_modules/croner": {
 			"version": "4.1.97",
 			"resolved": "https://registry.npmjs.org/croner/-/croner-4.1.97.tgz",
@@ -3383,6 +3461,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/diff-sequences": {
@@ -6747,6 +6834,18 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/keep-a-changelog": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-2.2.1.tgz",
+			"integrity": "sha512-SAqFQASEJFGJYk6SZ9RbyhZSRrpQyYB8+5r/PzEqIjVfSYczd/CapExulCoGEJEoLWY6FyH/Z72rKWyuKjg7UA==",
+			"dev": true,
+			"dependencies": {
+				"@deno/shim-deno": "~0.12.0"
+			},
+			"bin": {
+				"changelog": "esm/bin.js"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -8718,6 +8817,15 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/superstruct": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+			"integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8953,6 +9061,49 @@
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.2.tgz",
 			"integrity": "sha512-zvHx3VM83m2WYCE8XL99uaM7mFwYSkjR2OZti98fabHrwkjsCvgwChda5xctein3xGOyaQhtTeDq/1H/GNvF3A=="
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"dev": true,
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -9176,6 +9327,12 @@
 			"bin": {
 				"uuid": "bin/uuid"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.0.1",
@@ -9410,6 +9567,15 @@
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -9874,6 +10040,43 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.9",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.0.3",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
+			}
+		},
+		"@deno/shim-deno": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.12.0.tgz",
+			"integrity": "sha512-nD/Izdp4RfU35rip2Jx4lP1WOWY8qAvGLpB3wvjlwgut237/RS4PwhLdmYnxDBXdsjjWMx8sDxmdHWs35GF3yA==",
+			"dev": true,
+			"requires": {
+				"@deno/shim-deno-test": "^0.4.0",
+				"which": "^2.0.2"
+			}
+		},
+		"@deno/shim-deno-test": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.4.0.tgz",
+			"integrity": "sha512-oYWcD7CpERZy/TXMTM9Tgh1HD/POHlbY9WpzmAk+5H8DohcxG415Qws8yLGlim3EaKBT2v3lJv01x4G0BosnaQ==",
 			"dev": true
 		},
 		"@derhuerst/http-basic": {
@@ -10949,6 +11152,30 @@
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
+		"@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+			"dev": true
+		},
 		"@types/babel__core": {
 			"version": "7.1.20",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
@@ -11380,6 +11607,12 @@
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
 			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -11834,6 +12067,12 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
 		"croner": {
 			"version": "4.1.97",
 			"resolved": "https://registry.npmjs.org/croner/-/croner-4.1.97.tgz",
@@ -11933,6 +12172,12 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
 		},
 		"diff-sequences": {
@@ -14460,6 +14705,15 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"keep-a-changelog": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-2.2.1.tgz",
+			"integrity": "sha512-SAqFQASEJFGJYk6SZ9RbyhZSRrpQyYB8+5r/PzEqIjVfSYczd/CapExulCoGEJEoLWY6FyH/Z72rKWyuKjg7UA==",
+			"dev": true,
+			"requires": {
+				"@deno/shim-deno": "~0.12.0"
+			}
+		},
 		"kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -15899,6 +16153,12 @@
 				"peek-readable": "^5.0.0"
 			}
 		},
+		"superstruct": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+			"integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
+			"dev": true
+		},
 		"supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16042,6 +16302,27 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.2.tgz",
 			"integrity": "sha512-zvHx3VM83m2WYCE8XL99uaM7mFwYSkjR2OZti98fabHrwkjsCvgwChda5xctein3xGOyaQhtTeDq/1H/GNvF3A=="
+		},
+		"ts-node": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"dev": true,
+			"requires": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			}
 		},
 		"tsconfig-paths": {
 			"version": "3.14.1",
@@ -16204,6 +16485,12 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+		},
+		"v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true
 		},
 		"v8-to-istanbul": {
 			"version": "9.0.1",
@@ -16380,6 +16667,12 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"setup": "npm ci && npm run export-version && npm run build --production && npm run commands:deploy",
 		"commands:deploy": "node . --deploy",
 		"commands:revoke": "node . --revoke",
+		"release": "./node_modules/.bin/ts-node --esm -P tsconfig.test.json ./scripts/release.ts",
 		"db:init": "./node_modules/.bin/prisma migrate resolve --applied 20220915022732_initial_state  # TODO: Use this to set initial tables on the database",
 		"db:migrate": "./node_modules/.bin/prisma migrate deploy",
 		"db:introspect": "./node_modules/.bin/prisma db pull",
@@ -85,11 +86,15 @@
 		"jest": "28.1.3",
 		"jest-environment-node": "28.1.3",
 		"jest-extended": "3.1.0",
+		"keep-a-changelog": "2.2.1",
 		"nodemon": "2.0.20",
 		"prettier": "2.7.1",
 		"prettier-plugin-prisma": "4.4.0",
 		"prisma": "4.3.1",
+		"semver": "7.3.8",
+		"superstruct": "1.0.3",
 		"ts-jest": "28.0.8",
+		"ts-node": "10.9.1",
 		"typescript": "4.8.3"
 	}
 }

--- a/scripts/assertTsNode.ts
+++ b/scripts/assertTsNode.ts
@@ -1,0 +1,34 @@
+/**
+ * Asserts (on import) that the running context is ts-node.
+ *
+ * @throws an {@link EvalError} if the `ts-node` Service instance is not found on the process.
+ *
+ * See https://github.com/TypeStrong/ts-node/issues/846
+ */
+
+import type { Service } from 'ts-node';
+
+const REGISTER_INSTANCE = Symbol.for('ts-node.register.instance');
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace NodeJS {
+		interface Process {
+			[REGISTER_INSTANCE]?: Service;
+		}
+	}
+}
+
+let detectTSNode = false;
+
+try {
+	if (process[REGISTER_INSTANCE]) {
+		detectTSNode = true;
+	}
+} catch {}
+
+if (!detectTSNode) {
+	throw new EvalError(
+		"Couldn't detect the ts-node environment. Did you import this script as a module by mistake?"
+	);
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env ts-node
+
+import { assert, literal, string, type } from 'superstruct';
+import { parser as changelogParser } from 'keep-a-changelog';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import * as semver from 'semver';
+
+const logger = console;
+
+// Fixes the changelog's footer links and bumps the `version` in [package.json](/package.json) and [package-lock.json](/package-lock.json).
+// This script may be run repeatedly on the same project.
+
+const { parse: parseSemVer } = semver;
+
+function quote(str: string | undefined): string | undefined {
+	if (str === undefined) return str;
+	return `'${str}'`;
+}
+
+logger.info('** release.ts **');
+
+// Load the changelog
+const here = new URL(__filename, 'file:');
+const changelogPath = new URL('../CHANGELOG.md', here).pathname;
+const packageJsonPath = new URL('../package.json', here).pathname;
+const packageLockJsonPath = new URL('../package-lock.json', here).pathname;
+logger.info('Loading changelog from', quote(changelogPath));
+
+const rawChangelog = readFileSync(changelogPath, 'utf-8');
+const changelog = changelogParser(rawChangelog);
+
+const releases = changelog.releases;
+
+// Get current versioned release
+const thisReleaseIdx = releases.findIndex(release => release.date && release.version);
+const thisRelease = releases[thisReleaseIdx];
+if (!thisRelease?.version) throw new TypeError('No versioned release was found.');
+
+// Handy info
+logger.info('latest release:', thisRelease.version?.toString());
+
+const prevRelease = releases[thisReleaseIdx + 1];
+logger.info('previous release:', prevRelease?.version?.toString());
+
+// Fix the changelog's format (new compare links, etc.), and print the diff of our changes
+logger.info('\n** Spec compliance **');
+
+changelog.format = 'markdownlint';
+const newChangelog = changelog.toString();
+writeFileSync(changelogPath, newChangelog);
+
+const didFixChangelog = rawChangelog !== newChangelog;
+if (!didFixChangelog) {
+	logger.info('Changelog was already spec compliant.');
+} else {
+	logger.info('Fixed formatting for spec compliance.');
+}
+
+// Fix package.json and package-lock.json
+logger.info('\n** Version matching **');
+const versioned = type({
+	version: string(),
+});
+const versionedLock = type({
+	version: string(),
+	lockfileVersion: literal(2),
+	packages: type({
+		'': type({
+			version: string(),
+		}),
+	}),
+});
+
+const packageJson: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const packageLockJson: unknown = JSON.parse(readFileSync(packageLockJsonPath, 'utf-8'));
+
+assert(packageJson, versioned);
+assert(packageLockJson, versionedLock);
+
+const packageVersion = parseSemVer(packageJson.version);
+const packageLockVersion = parseSemVer(packageLockJson.version);
+
+if (!packageVersion) {
+	throw new TypeError(
+		'The "version" field in package.json is not a compliant Semantic Version number'
+	);
+}
+
+if (!packageLockVersion) {
+	throw new TypeError(
+		'The "version" field in package-lock.json is not a compliant Semantic Version number'
+	);
+}
+
+logger.info('package.json version:', packageVersion.version);
+logger.info('package-lock.json version:', packageLockVersion.version);
+
+if (packageVersion.version !== packageLockVersion.version) {
+	throw new EvalError(
+		'The "version" fields in package.json and package-lock.json do not match. Please let CHANGELOG.md be the source of truth for versioning. To ignore this warning and proceed, please first run `npm install`.'
+	);
+}
+
+// Update package.json
+const oldPackageJson = `${JSON.stringify(packageJson, undefined, '\t')}\n`;
+packageJson.version = thisRelease.version.version;
+const newPackageJson = `${JSON.stringify(packageJson, undefined, '\t')}\n`;
+writeFileSync(packageJsonPath, newPackageJson);
+
+const didFixPackageJson = oldPackageJson !== newPackageJson;
+if (!didFixPackageJson) {
+	logger.info('package.json already had the correct version.');
+} else {
+	logger.info('Updated package.json version.');
+}
+
+// Update package-lock.json
+const oldPackageLockJson = `${JSON.stringify(packageLockJson, undefined, '\t')}\n`;
+// Maybe we should just run `npm i` instead?
+packageLockJson.version = thisRelease.version.version;
+packageLockJson.packages[''].version = thisRelease.version.version;
+const newPackageLockJson = `${JSON.stringify(packageLockJson, undefined, '\t')}\n`;
+writeFileSync(packageLockJsonPath, newPackageLockJson);
+
+const didFixPackageLockJson = oldPackageLockJson !== newPackageLockJson;
+if (!didFixPackageLockJson) {
+	logger.info('package-lock.json already had the correct version.');
+} else {
+	logger.info('Updated package-lock.json version.');
+}
+
+// If we fixed the changelog or updated package.json, throw
+if (didFixChangelog || didFixPackageJson || didFixPackageLockJson) {
+	logger.warn('⚠️  We made some changes. Please review them and re-run. ⚠️');
+	process.exit(1); // this should fail us in CI
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env ts-node
 
+import './assertTsNode';
 import { assert, literal, string, type } from 'superstruct';
 import { parser as changelogParser } from 'keep-a-changelog';
 import { readFileSync, writeFileSync } from 'node:fs';

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
 		"noEmit": true,
 		"types": ["node", "jest", "jest-extended"]
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts", "scripts/**/*"]
 }


### PR DESCRIPTION
# New Process for Updating the Version

1. Update CHANGELOG.md
2. Run `npm run release`
3. ???
4. Profit

The script automatically adjusts the links at the bottom to match. Simply follow the regular format and all will be well.

Also added new CI/CD steps to automatically cut a new tag and GitHub Release page as new versions roll in.