### PR TITLE
Disable coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm test
 
       # - name: Report test coverage
-      #   uses: ArtiomTr/jest-coverage-report-action@v2.1.1
+      #   uses: ArtiomTr/jest-coverage-report-action@v2.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
 
       - name: Run unit tests
         run: npm test
-        env:
-          CI: true
-          NODE_ENV: 'test'
 
-      - name: Report test coverage
-        uses: ArtiomTr/jest-coverage-report-action@v2.1.1
+      # - name: Report test coverage
+      #   uses: ArtiomTr/jest-coverage-report-action@v2.1.1


### PR DESCRIPTION
It seems that `ArtiomTr/jest-coverage-report-action` doesn't support external PRs. I'm not certain that [the official workaround](https://github.com/ArtiomTr/jest-coverage-report-action#forks-with-no-write-permission) works for our purposes. I figure we should disable the coverage report for now, pending more research, since external contributions are ramping up.

Let's keep up coverage, though! We'll get a proper coverage report as soon as we figure out how to do that :P