### PR TITLE
Updated version of vulnerable undici dependency (pt. 2)

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -13,6 +13,7 @@
 	},
 	"extensionsToTreatAsEsm": [".ts"],
 	"moduleNameMapper": {
+		"^(\\.{1,2}/.*/llhttp\\.wasm\\.js)$": "$1",
 		"^(\\.{1,2}/.*)\\.js$": "$1"
 	},
 	"collectCoverage": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9253,9 +9253,9 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -16440,9 +16440,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-			"integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"requires": {
 				"busboy": "^1.6.0"
 			}


### PR DESCRIPTION
Based on #75, except we also fix our Jest config.

Thanks @josephgeis for the help on the dependency update, and credit goes to https://github.com/nodejs/undici/issues/1878#issuecomment-1421484960 for pointing out the solution for Jest.