### PR TITLE
Prefer Undici over Axios

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,
 	"git.branchProtection": ["main"],
-	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**"],
+	"todo-tree.filtering.excludeGlobs": ["**/dist/**", "**/node_modules/**", "coverage/**"],
 	"files.eol": "auto",
 	"terminal.integrated.defaultProfile.windows": "Git Bash",
 	"editor.formatOnSave": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
+[0.11.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.10.0...v0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2023-04-12
+
+### Changed
+
+- Use `undici` instead of `axios` for network requests.
+- Log HTTP status text when encountering non-200 statuses.
+- Properly guard API boundaries against type poisoning.
+
 ## [0.10.0] - 2023-04-06
 
 ### Added
@@ -181,6 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
+[0.10.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.9.0...v0.9.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.10.0",
+			"version": "0.10.1",
 			"license": "Unlicense",
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
@@ -4451,6 +4451,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globals/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -8154,18 +8166,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -11830,6 +11830,14 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
+				}
 			}
 		},
 		"globby": {
@@ -14512,12 +14520,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
-		},
-		"type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
 				"@prisma/client": "4.3.1",
-				"axios": "1.3.4",
 				"dectalk": "1.3.1",
 				"discord.js": "14.9.0",
 				"dotenv": "16.0.3",
@@ -21,6 +20,7 @@
 				"pm2": "5.2.2",
 				"source-map-support": "0.5.21",
 				"tmp": "0.2.1",
+				"undici": "5.21.2",
 				"yargs": "17.5.1"
 			},
 			"devDependencies": {
@@ -2463,21 +2463,6 @@
 				"semver": "bin/semver"
 			}
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"node_modules/axios": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-			"integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-			"dependencies": {
-				"follow-redirects": "^1.15.0",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
 		"node_modules/babel-jest": {
 			"version": "29.5.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
@@ -2929,17 +2914,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/commander": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -3109,14 +3083,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/depd": {
@@ -4236,19 +4202,6 @@
 				"debug": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -6049,25 +6002,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -8273,9 +8207,9 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.21.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+			"integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -8407,9 +8341,9 @@
 			}
 		},
 		"node_modules/vm2": {
-			"version": "3.9.13",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.13.tgz",
-			"integrity": "sha512-0rvxpB8P8Shm4wX2EKOiMp7H2zq+HUE/UwodY0pCZXs9IffIKZq6vUti5OgkVCTakKo9e/fgO4X1fkwfjWxE3Q==",
+			"version": "3.9.16",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
+			"integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
 			"dependencies": {
 				"acorn": "^8.7.0",
 				"acorn-walk": "^8.2.0"
@@ -10432,21 +10366,6 @@
 				}
 			}
 		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"axios": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-			"integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-			"requires": {
-				"follow-redirects": "^1.15.0",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
 		"babel-jest": {
 			"version": "29.5.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
@@ -10770,14 +10689,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -10916,11 +10827,6 @@
 				"esprima": "^4.0.0",
 				"vm2": "^3.9.8"
 			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"depd": {
 			"version": "2.0.0",
@@ -11747,16 +11653,6 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
 			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-		},
-		"form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"fs-extra": {
 			"version": "8.1.0",
@@ -13094,19 +12990,6 @@
 			"requires": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"requires": {
-				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
@@ -14669,9 +14552,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.21.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+			"integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
 			"requires": {
 				"busboy": "^1.6.0"
 			}
@@ -14772,9 +14655,9 @@
 			}
 		},
 		"vm2": {
-			"version": "3.9.13",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.13.tgz",
-			"integrity": "sha512-0rvxpB8P8Shm4wX2EKOiMp7H2zq+HUE/UwodY0pCZXs9IffIKZq6vUti5OgkVCTakKo9e/fgO4X1fkwfjWxE3Q==",
+			"version": "3.9.16",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
+			"integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
 			"requires": {
 				"acorn": "^8.7.0",
 				"acorn-walk": "^8.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"lodash": "4.17.21",
 				"pm2": "5.2.2",
 				"source-map-support": "0.5.21",
+				"superstruct": "1.0.3",
 				"tmp": "0.2.1",
 				"undici": "5.21.2",
 				"yargs": "17.5.1"
@@ -52,7 +53,6 @@
 				"prettier-plugin-prisma": "4.10.0",
 				"prisma": "4.3.1",
 				"semver": "7.3.8",
-				"superstruct": "1.0.3",
 				"ts-jest": "29.0.5",
 				"ts-node": "10.9.1",
 				"typescript": "4.9.5"
@@ -7812,7 +7812,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
 			"integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
-			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -14297,8 +14296,7 @@
 		"superstruct": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
-			"integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
-			"dev": true
+			"integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg=="
 		},
 		"supports-color": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csbot",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "The One beneath the Supreme Overlord's rule. A bot to help manage the BYU CS Discord, successor to Ze Kaiser (https://github.com/arkenstorm/ze-kaiser)",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 	"dependencies": {
 		"@discordjs/voice": "0.15.0",
 		"@prisma/client": "4.3.1",
-		"axios": "1.3.4",
 		"dectalk": "1.3.1",
 		"discord.js": "14.9.0",
 		"dotenv": "16.0.3",
@@ -62,6 +61,7 @@
 		"pm2": "5.2.2",
 		"source-map-support": "0.5.21",
 		"tmp": "0.2.1",
+		"undici": "5.21.2",
 		"yargs": "17.5.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"lodash": "4.17.21",
 		"pm2": "5.2.2",
 		"source-map-support": "0.5.21",
+		"superstruct": "1.0.3",
 		"tmp": "0.2.1",
 		"undici": "5.21.2",
 		"yargs": "17.5.1"
@@ -93,7 +94,6 @@
 		"prettier-plugin-prisma": "4.10.0",
 		"prisma": "4.3.1",
 		"semver": "7.3.8",
-		"superstruct": "1.0.3",
 		"ts-jest": "29.0.5",
 		"ts-node": "10.9.1",
 		"typescript": "4.9.5"

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -1,6 +1,7 @@
 import { array, assert, boolean, string, tuple, type as schema } from 'superstruct';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
+import { URL } from 'node:url';
 
 import * as logger from '../logger';
 
@@ -83,7 +84,7 @@ export function convertTo12Hour(time: string): string {
 	return 'ERR';
 }
 
-async function _getRoomsFromEndpoint(endpoint: string): Promise<GetRoomsResponse> {
+async function _getRoomsFromEndpoint(endpoint: URL): Promise<GetRoomsResponse> {
 	try {
 		const res = await fetch(endpoint);
 		const status = res.status;
@@ -102,12 +103,12 @@ async function _getRoomsFromEndpoint(endpoint: string): Promise<GetRoomsResponse
 }
 
 async function _getRoomsNow(building: string): Promise<GetRoomsResponse> {
-	const url = `https://pi.zyancey.com/now/${building}`;
+	const url = new URL(`https://pi.zyancey.com/now/${building}`);
 	return await _getRoomsFromEndpoint(url);
 }
 
 async function _getRoomsAt(building: string, timeA: string): Promise<GetRoomsResponse> {
-	const url = `https://pi.zyancey.com/at/${building}/${timeA}`;
+	const url = new URL(`https://pi.zyancey.com/at/${building}/${timeA}`);
 	return await _getRoomsFromEndpoint(url);
 }
 
@@ -116,7 +117,7 @@ async function _getRoomsBetween(
 	timeA: string,
 	timeB: string
 ): Promise<GetRoomsResponse> {
-	const url = `https://pi.zyancey.com/between/${building}/${timeA}/${timeB}`;
+	const url = new URL(`https://pi.zyancey.com/between/${building}/${timeA}/${timeB}`);
 	return await _getRoomsFromEndpoint(url);
 }
 

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -1,7 +1,6 @@
-import { array, assert, boolean, string, tuple, type as schema } from 'superstruct';
-import { describeCode, HttpStatusCode } from '../helpers/HttpStatusCode';
+import { array, boolean, string, tuple, type as schema } from 'superstruct';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import { fetch } from 'undici';
+import { fetch } from '../helpers/fetch';
 import { URL } from 'node:url';
 
 import * as logger from '../logger';
@@ -87,14 +86,7 @@ export function convertTo12Hour(time: string): string {
 
 async function _getRoomsFromEndpoint(endpoint: URL): Promise<GetRoomsResponse> {
 	try {
-		const res = await fetch(endpoint);
-		if (res.status !== HttpStatusCode.OK) {
-			throw new Error(`${res.status}: ${describeCode(res.status)}`);
-		}
-
-		const data = await res.json();
-		assert(data, getRoomsResponse);
-		return data;
+		return await fetch(endpoint, getRoomsResponse);
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);
@@ -126,14 +118,7 @@ async function _getRoomsBetween(
 
 async function _getWhenRoom(building: string, room: string): Promise<GetRoomInfoResponse> {
 	try {
-		const res = await fetch(`https://pi.zyancey.com/when/${building}/${room}`);
-		if (res.status !== HttpStatusCode.OK) {
-			throw new Error(`${res.status}: ${describeCode(res.status)}`);
-		}
-
-		const data = await res.json();
-		assert(data, getRoomInfoResponse);
-		return data;
+		return await fetch(`https://pi.zyancey.com/when/${building}/${room}`, getRoomInfoResponse);
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import axios from 'axios';
+import { fetch } from 'undici';
 
 import * as logger from '../logger';
 
@@ -80,9 +80,11 @@ export function convertTo12Hour(time: string): string {
 
 async function _getRoomsFromEndpoint(endpoint: string): Promise<GetRoomsResponse> {
 	try {
-		const { data, status } = await axios.get<GetRoomsResponse>(endpoint);
+		const res = await fetch(endpoint);
+		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
-		return data;
+		const data = await res.json();
+		return data as GetRoomsResponse;
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);
@@ -114,11 +116,11 @@ async function _getRoomsBetween(
 
 async function _getWhenRoom(building: string, room: string): Promise<GetRoomInfoResponse> {
 	try {
-		const { data, status } = await axios.get<GetRoomInfoResponse>(
-			`https://pi.zyancey.com/when/${building}/${room}`
-		);
+		const res = await fetch(`https://pi.zyancey.com/when/${building}/${room}`);
+		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
-		return data;
+		const data = await res.json();
+		return data as GetRoomInfoResponse;
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -1,17 +1,22 @@
+import { array, assert, boolean, string, tuple, type as schema } from 'superstruct';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
 
 import * as logger from '../logger';
 
-interface GetRoomInfoResponse {
-	busySince: string;
-	busyUntil: string;
-	isInUse: boolean;
-}
+const getRoomInfoResponse = schema({
+	busySince: string(),
+	busyUntil: string(),
+	isInUse: boolean(),
+});
 
-interface GetRoomsResponse {
-	Rooms: Array<[string, string]>;
-}
+type GetRoomInfoResponse = typeof getRoomInfoResponse.TYPE;
+
+const getRoomsResponse = schema({
+	Rooms: array(tuple([string(), string()])),
+});
+
+type GetRoomsResponse = typeof getRoomsResponse.TYPE;
 
 const timeChoices = [
 	{ name: '8:00 AM', value: '08:00:00' },
@@ -84,7 +89,8 @@ async function _getRoomsFromEndpoint(endpoint: string): Promise<GetRoomsResponse
 		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
 		const data = await res.json();
-		return data as GetRoomsResponse;
+		assert(data, getRoomsResponse);
+		return data;
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);
@@ -120,7 +126,8 @@ async function _getWhenRoom(building: string, room: string): Promise<GetRoomInfo
 		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
 		const data = await res.json();
-		return data as GetRoomInfoResponse;
+		assert(data, getRoomInfoResponse);
+		return data;
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -1,4 +1,5 @@
 import { array, assert, boolean, string, tuple, type as schema } from 'superstruct';
+import { describeCode, HttpStatusCode } from '../helpers/HttpStatusCode';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
 import { URL } from 'node:url';
@@ -87,8 +88,10 @@ export function convertTo12Hour(time: string): string {
 async function _getRoomsFromEndpoint(endpoint: URL): Promise<GetRoomsResponse> {
 	try {
 		const res = await fetch(endpoint);
-		const status = res.status;
-		if (status !== 200) throw new Error(`${status}`);
+		if (res.status !== HttpStatusCode.OK) {
+			throw new Error(`${res.status}: ${describeCode(res.status)}`);
+		}
+
 		const data = await res.json();
 		assert(data, getRoomsResponse);
 		return data;
@@ -124,8 +127,10 @@ async function _getRoomsBetween(
 async function _getWhenRoom(building: string, room: string): Promise<GetRoomInfoResponse> {
 	try {
 		const res = await fetch(`https://pi.zyancey.com/when/${building}/${room}`);
-		const status = res.status;
-		if (status !== 200) throw new Error(`${status}`);
+		if (res.status !== HttpStatusCode.OK) {
+			throw new Error(`${res.status}: ${describeCode(res.status)}`);
+		}
+
 		const data = await res.json();
 		assert(data, getRoomInfoResponse);
 		return data;

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -118,7 +118,8 @@ async function _getRoomsBetween(
 
 async function _getWhenRoom(building: string, room: string): Promise<GetRoomInfoResponse> {
 	try {
-		return await fetch(`https://pi.zyancey.com/when/${building}/${room}`, getRoomInfoResponse);
+		const endpoint = new URL(`https://pi.zyancey.com/when/${building}/${room}`);
+		return await fetch(endpoint, getRoomInfoResponse);
 	} catch (error_) {
 		logger.error('Error in getting Room Info:');
 		logger.error(error_);

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -2,6 +2,7 @@
 import { assert, number, string, type as schema } from 'superstruct';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
+import { URL } from 'node:url';
 
 // Internal dependencies
 import * as logger from '../logger';
@@ -40,7 +41,9 @@ async function _latestCheck(): Promise<GetComicResponse> {
 
 async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 	try {
-		const res = await fetch(`https://xkcd.now.sh/?comic=${endpoint}`);
+		const url = new URL('https://xkcd.now.sh/');
+		url.searchParams.set('comic', `${endpoint}`);
+		const res = await fetch(url);
 		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
 		const data = await res.json();

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -1,8 +1,7 @@
 // External dependencies
-import { assert, number, string, type as schema } from 'superstruct';
-import { describeCode, HttpStatusCode } from '../helpers/HttpStatusCode';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import { fetch } from 'undici';
+import { fetch } from '../helpers/fetch';
+import { number, string, type as schema } from 'superstruct';
 import { URL } from 'node:url';
 
 // Internal dependencies
@@ -44,14 +43,7 @@ async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 	try {
 		const url = new URL('https://xkcd.now.sh/');
 		url.searchParams.set('comic', `${endpoint}`);
-		const res = await fetch(url);
-		if (res.status !== HttpStatusCode.OK) {
-			throw new Error(`${res.status}: ${describeCode(res.status)}`);
-		}
-
-		const data = await res.json();
-		assert(data, getComicResponse);
-		return data;
+		return await fetch(url, getComicResponse);
 	} catch (error_) {
 		logger.error('Error in getting an XKCD comic:');
 		logger.error(error_);

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -1,6 +1,6 @@
 // External dependencies
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import axios from 'axios';
+import { fetch } from 'undici';
 
 // Internal dependencies
 import * as logger from '../logger';
@@ -37,12 +37,11 @@ async function _latestCheck(): Promise<GetComicResponse> {
 
 async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 	try {
-		const { data, status } = await axios.get<GetComicResponse>(
-			`https://xkcd.now.sh/?comic=${endpoint}`
-		);
-		// TODO: BUILD A TYPE GUARD AROUND THIS
+		const res = await fetch(`https://xkcd.now.sh/?comic=${endpoint}`);
+		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
-		return data;
+		const data = await res.json();
+		return data as GetComicResponse; // TODO: BUILD A TYPE GUARD AROUND THIS
 	} catch (error_) {
 		logger.error('Error in getting an XKCD comic:');
 		logger.error(error_);

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -1,4 +1,5 @@
 // External dependencies
+import { assert, number, string, type as schema } from 'superstruct';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
 
@@ -6,19 +7,21 @@ import { fetch } from 'undici';
 import * as logger from '../logger';
 import { UserMessageError } from '../helpers/UserMessageError';
 
-interface GetComicResponse {
-	month: string;
-	num: number;
-	link: string;
-	news: string;
-	safe_title: string;
-	transcript: string;
-	alt: string;
-	year: string;
-	title: string;
-	day: string;
-	img: string;
-}
+const getComicResponse = schema({
+	month: string(),
+	num: number(),
+	link: string(),
+	news: string(),
+	safe_title: string(),
+	transcript: string(),
+	alt: string(),
+	year: string(),
+	title: string(),
+	day: string(),
+	img: string(),
+});
+
+type GetComicResponse = typeof getComicResponse.TYPE;
 
 /**
  * a quick call to see the latest comic.
@@ -41,7 +44,8 @@ async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 		const status = res.status;
 		if (status !== 200) throw new Error(`${status}`);
 		const data = await res.json();
-		return data as GetComicResponse; // TODO: BUILD A TYPE GUARD AROUND THIS
+		assert(data, getComicResponse);
+		return data;
 	} catch (error_) {
 		logger.error('Error in getting an XKCD comic:');
 		logger.error(error_);

--- a/src/commands/xkcd.ts
+++ b/src/commands/xkcd.ts
@@ -1,5 +1,6 @@
 // External dependencies
 import { assert, number, string, type as schema } from 'superstruct';
+import { describeCode, HttpStatusCode } from '../helpers/HttpStatusCode';
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { fetch } from 'undici';
 import { URL } from 'node:url';
@@ -44,8 +45,10 @@ async function _getComic(endpoint: string | number): Promise<GetComicResponse> {
 		const url = new URL('https://xkcd.now.sh/');
 		url.searchParams.set('comic', `${endpoint}`);
 		const res = await fetch(url);
-		const status = res.status;
-		if (status !== 200) throw new Error(`${status}`);
+		if (res.status !== HttpStatusCode.OK) {
+			throw new Error(`${res.status}: ${describeCode(res.status)}`);
+		}
+
 		const data = await res.json();
 		assert(data, getComicResponse);
 		return data;

--- a/src/helpers/HttpStatusCode.ts
+++ b/src/helpers/HttpStatusCode.ts
@@ -1,0 +1,409 @@
+/**
+ * @see https://gist.github.com/scokmen/f813c904ef79022e84ab2409574d1b45
+ */
+
+/**
+ * Hypertext Transfer Protocol (HTTP) response status codes.
+ * @see https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+ */
+export enum HttpStatusCode {
+	/**
+	 * The server has received the request headers and the client should proceed to send the request body
+	 * (in the case of a request for which a body needs to be sent; for example, a POST request).
+	 * Sending a large request body to a server after a request has been rejected for inappropriate headers would be inefficient.
+	 * To have a server check the request's headers, a client must send Expect: 100-continue as a header in its initial request
+	 * and receive a 100 Continue status code in response before sending the body. The response 417 Expectation Failed indicates the request should not be continued.
+	 */
+	CONTINUE = 100,
+
+	/**
+	 * The requester has asked the server to switch protocols and the server has agreed to do so.
+	 */
+	SWITCHING_PROTOCOLS = 101,
+
+	/**
+	 * A WebDAV request may contain many sub-requests involving file operations, requiring a long time to complete the request.
+	 * This code indicates that the server has received and is processing the request, but no response is available yet.
+	 * This prevents the client from timing out and assuming the request was lost.
+	 */
+	PROCESSING = 102,
+
+	/**
+	 * Standard response for successful HTTP requests.
+	 * The actual response will depend on the request method used.
+	 * In a GET request, the response will contain an entity corresponding to the requested resource.
+	 * In a POST request, the response will contain an entity describing or containing the result of the action.
+	 */
+	OK = 200,
+
+	/**
+	 * The request has been fulfilled, resulting in the creation of a new resource.
+	 */
+	CREATED = 201,
+
+	/**
+	 * The request has been accepted for processing, but the processing has not been completed.
+	 * The request might or might not be eventually acted upon, and may be disallowed when processing occurs.
+	 */
+	ACCEPTED = 202,
+
+	/**
+	 * SINCE HTTP/1.1
+	 * The server is a transforming proxy that received a 200 OK from its origin,
+	 * but is returning a modified version of the origin's response.
+	 */
+	NON_AUTHORITATIVE_INFORMATION = 203,
+
+	/**
+	 * The server successfully processed the request and is not returning any content.
+	 */
+	NO_CONTENT = 204,
+
+	/**
+	 * The server successfully processed the request, but is not returning any content.
+	 * Unlike a 204 response, this response requires that the requester reset the document view.
+	 */
+	RESET_CONTENT = 205,
+
+	/**
+	 * The server is delivering only part of the resource (byte serving) due to a range header sent by the client.
+	 * The range header is used by HTTP clients to enable resuming of interrupted downloads,
+	 * or split a download into multiple simultaneous streams.
+	 */
+	PARTIAL_CONTENT = 206,
+
+	/**
+	 * The message body that follows is an XML message and can contain a number of separate response codes,
+	 * depending on how many sub-requests were made.
+	 */
+	MULTI_STATUS = 207,
+
+	/**
+	 * The members of a DAV binding have already been enumerated in a preceding part of the (multistatus) response,
+	 * and are not being included again.
+	 */
+	ALREADY_REPORTED = 208,
+
+	/**
+	 * The server has fulfilled a request for the resource,
+	 * and the response is a representation of the result of one or more instance-manipulations applied to the current instance.
+	 */
+	IM_USED = 226,
+
+	/**
+	 * Indicates multiple options for the resource from which the client may choose (via agent-driven content negotiation).
+	 * For example, this code could be used to present multiple video format options,
+	 * to list files with different filename extensions, or to suggest word-sense disambiguation.
+	 */
+	MULTIPLE_CHOICES = 300,
+
+	/**
+	 * This and all future requests should be directed to the given URI.
+	 */
+	MOVED_PERMANENTLY = 301,
+
+	/**
+	 * This is an example of industry practice contradicting the standard.
+	 * The HTTP/1.0 specification (RFC 1945) required the client to perform a temporary redirect
+	 * (the original describing phrase was "Moved Temporarily"), but popular browsers implemented 302
+	 * with the functionality of a 303 See Other. Therefore, HTTP/1.1 added status codes 303 and 307
+	 * to distinguish between the two behaviours. However, some Web applications and frameworks
+	 * use the 302 status code as if it were the 303.
+	 */
+	FOUND = 302,
+
+	/**
+	 * SINCE HTTP/1.1
+	 * The response to the request can be found under another URI using a GET method.
+	 * When received in response to a POST (or PUT/DELETE), the client should presume that
+	 * the server has received the data and should issue a redirect with a separate GET message.
+	 */
+	SEE_OTHER = 303,
+
+	/**
+	 * Indicates that the resource has not been modified since the version specified by the request headers If-Modified-Since or If-None-Match.
+	 * In such case, there is no need to retransmit the resource since the client still has a previously-downloaded copy.
+	 */
+	NOT_MODIFIED = 304,
+
+	/**
+	 * SINCE HTTP/1.1
+	 * The requested resource is available only through a proxy, the address for which is provided in the response.
+	 * Many HTTP clients (such as Mozilla and Internet Explorer) do not correctly handle responses with this status code, primarily for security reasons.
+	 */
+	USE_PROXY = 305,
+
+	/**
+	 * No longer used. Originally meant "Subsequent requests should use the specified proxy."
+	 */
+	SWITCH_PROXY = 306,
+
+	/**
+	 * SINCE HTTP/1.1
+	 * In this case, the request should be repeated with another URI; however, future requests should still use the original URI.
+	 * In contrast to how 302 was historically implemented, the request method is not allowed to be changed when reissuing the original request.
+	 * For example, a POST request should be repeated using another POST request.
+	 */
+	TEMPORARY_REDIRECT = 307,
+
+	/**
+	 * The request and all future requests should be repeated using another URI.
+	 * 307 and 308 parallel the behaviors of 302 and 301, but do not allow the HTTP method to change.
+	 * So, for example, submitting a form to a permanently redirected resource may continue smoothly.
+	 */
+	PERMANENT_REDIRECT = 308,
+
+	/**
+	 * The server cannot or will not process the request due to an apparent client error
+	 * (e.g., malformed request syntax, too large size, invalid request message framing, or deceptive request routing).
+	 */
+	BAD_REQUEST = 400,
+
+	/**
+	 * Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet
+	 * been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the
+	 * requested resource. See Basic access authentication and Digest access authentication. 401 semantically means
+	 * "unauthenticated",i.e. the user does not have the necessary credentials.
+	 */
+	UNAUTHORIZED = 401,
+
+	/**
+	 * Reserved for future use. The original intention was that this code might be used as part of some form of digital
+	 * cash or micro payment scheme, but that has not happened, and this code is not usually used.
+	 * Google Developers API uses this status if a particular developer has exceeded the daily limit on requests.
+	 */
+	PAYMENT_REQUIRED = 402,
+
+	/**
+	 * The request was valid, but the server is refusing action.
+	 * The user might not have the necessary permissions for a resource.
+	 */
+	FORBIDDEN = 403,
+
+	/**
+	 * The requested resource could not be found but may be available in the future.
+	 * Subsequent requests by the client are permissible.
+	 */
+	NOT_FOUND = 404,
+
+	/**
+	 * A request method is not supported for the requested resource;
+	 * for example, a GET request on a form that requires data to be presented via POST, or a PUT request on a read-only resource.
+	 */
+	METHOD_NOT_ALLOWED = 405,
+
+	/**
+	 * The requested resource is capable of generating only content not acceptable according to the Accept headers sent in the request.
+	 */
+	NOT_ACCEPTABLE = 406,
+
+	/**
+	 * The client must first authenticate itself with the proxy.
+	 */
+	PROXY_AUTHENTICATION_REQUIRED = 407,
+
+	/**
+	 * The server timed out waiting for the request.
+	 * According to HTTP specifications:
+	 * "The client did not produce a request within the time that the server was prepared to wait. The client MAY repeat the request without modifications at any later time."
+	 */
+	REQUEST_TIMEOUT = 408,
+
+	/**
+	 * Indicates that the request could not be processed because of conflict in the request,
+	 * such as an edit conflict between multiple simultaneous updates.
+	 */
+	CONFLICT = 409,
+
+	/**
+	 * Indicates that the resource requested is no longer available and will not be available again.
+	 * This should be used when a resource has been intentionally removed and the resource should be purged.
+	 * Upon receiving a 410 status code, the client should not request the resource in the future.
+	 * Clients such as search engines should remove the resource from their indices.
+	 * Most use cases do not require clients and search engines to purge the resource, and a "404 Not Found" may be used instead.
+	 */
+	GONE = 410,
+
+	/**
+	 * The request did not specify the length of its content, which is required by the requested resource.
+	 */
+	LENGTH_REQUIRED = 411,
+
+	/**
+	 * The server does not meet one of the preconditions that the requester put on the request.
+	 */
+	PRECONDITION_FAILED = 412,
+
+	/**
+	 * The request is larger than the server is willing or able to process. Previously called "Request Entity Too Large".
+	 */
+	PAYLOAD_TOO_LARGE = 413,
+
+	/**
+	 * The URI provided was too long for the server to process. Often the result of too much data being encoded as a query-string of a GET request,
+	 * in which case it should be converted to a POST request.
+	 * Called "Request-URI Too Long" previously.
+	 */
+	URI_TOO_LONG = 414,
+
+	/**
+	 * The request entity has a media type which the server or resource does not support.
+	 * For example, the client uploads an image as image/svg+xml, but the server requires that images use a different format.
+	 */
+	UNSUPPORTED_MEDIA_TYPE = 415,
+
+	/**
+	 * The client has asked for a portion of the file (byte serving), but the server cannot supply that portion.
+	 * For example, if the client asked for a part of the file that lies beyond the end of the file.
+	 * Called "Requested Range Not Satisfiable" previously.
+	 */
+	RANGE_NOT_SATISFIABLE = 416,
+
+	/**
+	 * The server cannot meet the requirements of the Expect request-header field.
+	 */
+	EXPECTATION_FAILED = 417,
+
+	/**
+	 * This code was defined in 1998 as one of the traditional IETF April Fools' jokes, in RFC 2324, Hyper Text Coffee Pot Control Protocol,
+	 * and is not expected to be implemented by actual HTTP servers. The RFC specifies this code should be returned by
+	 * teapots requested to brew coffee. This HTTP status is used as an Easter egg in some websites, including Google.com.
+	 */
+	I_AM_A_TEAPOT = 418,
+
+	/**
+	 * The request was directed at a server that is not able to produce a response (for example because a connection reuse).
+	 */
+	MISDIRECTED_REQUEST = 421,
+
+	/**
+	 * The request was well-formed but was unable to be followed due to semantic errors.
+	 */
+	UNPROCESSABLE_ENTITY = 422,
+
+	/**
+	 * The resource that is being accessed is locked.
+	 */
+	LOCKED = 423,
+
+	/**
+	 * The request failed due to failure of a previous request (e.g., a PROPPATCH).
+	 */
+	FAILED_DEPENDENCY = 424,
+
+	/**
+	 * The server is unwilling to risk processing a request that might be replayed,
+	 * which creates the potential for a replay attack.
+	 */
+	TOO_EARLY = 425,
+
+	/**
+	 * The client should switch to a different protocol such as TLS/1.0, given in the Upgrade header field.
+	 */
+	UPGRADE_REQUIRED = 426,
+
+	/**
+	 * The origin server requires the request to be conditional.
+	 * Intended to prevent "the 'lost update' problem, where a client
+	 * GETs a resource's state, modifies it, and PUTs it back to the server,
+	 * when meanwhile a third party has modified the state on the server, leading to a conflict."
+	 */
+	PRECONDITION_REQUIRED = 428,
+
+	/**
+	 * The user has sent too many requests in a given amount of time. Intended for use with rate-limiting schemes.
+	 */
+	TOO_MANY_REQUESTS = 429,
+
+	/**
+	 * The server is unwilling to process the request because either an individual header field,
+	 * or all the header fields collectively, are too large.
+	 */
+	REQUEST_HEADER_FIELDS_TOO_LARGE = 431,
+
+	/**
+	 * A server operator has received a legal demand to deny access to a resource or to a set of resources
+	 * that includes the requested resource. The code 451 was chosen as a reference to the novel Fahrenheit 451.
+	 */
+	UNAVAILABLE_FOR_LEGAL_REASONS = 451,
+
+	/**
+	 * A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
+	 */
+	INTERNAL_SERVER_ERROR = 500,
+
+	/**
+	 * The server either does not recognize the request method, or it lacks the ability to fulfill the request.
+	 * Usually this implies future availability (e.g., a new feature of a web-service API).
+	 */
+	NOT_IMPLEMENTED = 501,
+
+	/**
+	 * The server was acting as a gateway or proxy and received an invalid response from the upstream server.
+	 */
+	BAD_GATEWAY = 502,
+
+	/**
+	 * The server is currently unavailable (because it is overloaded or down for maintenance).
+	 * Generally, this is a temporary state.
+	 */
+	SERVICE_UNAVAILABLE = 503,
+
+	/**
+	 * The server was acting as a gateway or proxy and did not receive a timely response from the upstream server.
+	 */
+	GATEWAY_TIMEOUT = 504,
+
+	/**
+	 * The server does not support the HTTP protocol version used in the request
+	 */
+	HTTP_VERSION_NOT_SUPPORTED = 505,
+
+	/**
+	 * Transparent content negotiation for the request results in a circular reference.
+	 */
+	VARIANT_ALSO_NEGOTIATES = 506,
+
+	/**
+	 * The server is unable to store the representation needed to complete the request.
+	 */
+	INSUFFICIENT_STORAGE = 507,
+
+	/**
+	 * The server detected an infinite loop while processing the request.
+	 */
+	LOOP_DETECTED = 508,
+
+	/**
+	 * Further extensions to the request are required for the server to fulfill it.
+	 */
+	NOT_EXTENDED = 510,
+
+	/**
+	 * The client needs to authenticate to gain network access.
+	 * Intended for use by intercepting proxies used to control access to the network (e.g., "captive portals" used
+	 * to require agreement to Terms of Service before granting full Internet access via a Wi-Fi hotspot).
+	 */
+	NETWORK_AUTHENTICATION_REQUIRED = 511,
+
+	/**
+	 * An unofficial server error specific to Cloudflare and Pantheon.
+	 *
+	 * In the case of Cloudflare, a second HTTP status code `1XXX error
+	 * message` will be included to provide a more accurate description
+	 * of the problem. For Pantheon, HTTP status code `530 Site Frozen`
+	 * indicates that a site has been restricted due to inactivity.
+	 *
+	 * @see https://http.dev/530
+	 */
+	SITE_FROZEN = 530,
+}
+
+/**
+ * Returns a brief textual description of the status code.
+ */
+export function describeCode(code: HttpStatusCode): string {
+	// Since HTTP clients no longer populate the `statusText` field, we must provide our own.
+	// It is taking me every ounce of willpower not to paste in my switch of pony puns here.
+	return HttpStatusCode[code] ?? `HTTP_${code}`;
+}

--- a/src/helpers/NetworkError.ts
+++ b/src/helpers/NetworkError.ts
@@ -1,0 +1,17 @@
+import { describeCode, HttpStatusCode } from './HttpStatusCode';
+
+/**
+ * An object that represents an HTTP status returned from an API request.
+ */
+export class NetworkError extends Error {
+	readonly code: HttpStatusCode;
+	readonly statusText: string;
+
+	constructor(code: HttpStatusCode) {
+		const statusText = describeCode(code);
+		super(`HTTP ${code}: ${statusText}`);
+		this.code = code;
+		this.statusText = statusText;
+		this.name = 'NetworkError';
+	}
+}

--- a/src/helpers/fetch.test.ts
+++ b/src/helpers/fetch.test.ts
@@ -1,0 +1,60 @@
+import type { Response } from 'undici';
+import { fetch } from './fetch';
+import { fetch as _fetch } from 'undici';
+import { HttpStatusCode } from './HttpStatusCode';
+import { NetworkError } from './NetworkError';
+import { string, type as schema, StructError } from 'superstruct';
+import { URL } from 'node:url';
+
+jest.mock('undici', () => ({ fetch: jest.fn() }));
+
+const mockUndici = _fetch as jest.Mock<ReturnType<typeof _fetch>, Parameters<typeof _fetch>>;
+
+describe('fetch', () => {
+	const url = new URL('https://example.com');
+	const struct = schema({
+		foo: string(),
+	});
+
+	beforeEach(() => {
+		mockUndici.mockRejectedValue(new Error('This is a test'));
+	});
+
+	test('returns well-formed data with 200 response', async () => {
+		const res = { foo: 'bar' };
+		mockUndici.mockResolvedValueOnce({
+			status: HttpStatusCode.OK,
+			statusText: '',
+			json: () => Promise.resolve(res),
+		} as unknown as Response);
+
+		const data = await fetch(url, struct);
+		expect(mockUndici).toHaveBeenCalledOnceWith(url);
+		expect(data).toStrictEqual(res);
+	});
+
+	test('throws a NetworkError with non-200 response', async () => {
+		mockUndici.mockResolvedValueOnce({
+			status: HttpStatusCode.BAD_REQUEST,
+			statusText: '',
+			json: () => Promise.reject(new Error('bad')),
+		} as unknown as Response);
+
+		await expect(() => fetch(url, struct)).rejects.toStrictEqual(
+			new NetworkError(HttpStatusCode.BAD_REQUEST)
+		);
+		expect(mockUndici).toHaveBeenCalledOnceWith(url);
+	});
+
+	test('throws a StructError with malformed data', async () => {
+		const res = { foo: 42, bar: 'baz' };
+		mockUndici.mockResolvedValueOnce({
+			status: HttpStatusCode.OK,
+			statusText: '',
+			json: () => Promise.resolve(res),
+		} as unknown as Response);
+
+		await expect(() => fetch(url, struct)).rejects.toThrow(StructError);
+		expect(mockUndici).toHaveBeenCalledOnceWith(url);
+	});
+});

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -1,0 +1,35 @@
+import type { RequestInfo, RequestInit } from 'undici';
+import type { Struct, StructError } from 'superstruct'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { assert } from 'superstruct';
+import { HttpStatusCode } from './HttpStatusCode';
+import { fetch as _fetch } from 'undici';
+import { NetworkError } from './NetworkError';
+
+/**
+ * Performs a network request.
+ *
+ * @param input The URL to request.
+ * @param struct A schema that describes the type data to expect back.
+ * @param init Additional information about the request.
+ *
+ * @throws a {@link NetworkError} if the response status is not `OK`,
+ * a {@link StructError} if the data does not match the given schema,
+ * or some Undici error otherwise.
+ * @returns A promise that resolves with the requested data.
+ */
+export async function fetch<T, S>(
+	input: RequestInfo,
+	struct: Struct<T, S>,
+	init?: RequestInit
+): Promise<T> {
+	const res = await _fetch(input, init);
+
+	const status = res.status;
+	if (status !== HttpStatusCode.OK) {
+		throw new NetworkError(status);
+	}
+
+	const data = await res.json();
+	assert(data, struct);
+	return data;
+}


### PR DESCRIPTION
Since [Node 18 includes the `fetch` API](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental) (and that support is [no longer experimental](https://stackoverflow.com/a/75221620)), we can drop a dependency when we upgrade. Since Node's `fetch` implementation is `undici`, I think it would be prudent to use that one for now. Once we're on Node 18, we can remove `undici` (or [move it into devDependencies for type information](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924#issuecomment-1504635244)) for a smaller bundle.

Axios is a fine package, as far as I can tell, and very popular, even since Node 18. The `fetch` API is also popular (see [`node-fetch`](https://github.com/node-fetch/node-fetch) and the browser-native [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) API). I consider both to be industry standard REST client implementations. Since Node has added the `fetch` API natively, thus presenting a chance to drop an external dependency, I'd prefer to go that route.

## Notable Changes
- Replaced `axios` with `undici`, in preparation for Node 18.
- Used `superstruct` to create type guards at API boundaries.
- Log HTTP status messages along with non-200 status codes.