### PR TITLE
Revamp GitHub workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Parse Changelog
+      - name: Parse changelog
         id: changelog
         uses: coditory/changelog-parser@v1.0.2
 
-      - name: Publish Release
+      - name: Publish release
         if: steps.changelog.outputs.status != 'unreleased'
         # This action doesn't create a new release if the tag already exists
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Parse Changelog
         id: changelog

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Create release
 
 # On push to main, if the latest version in CHANGELOG.md is different from the latest version tag, create a new tag and release
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Validate
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     container:
       image: node:18.17.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,8 @@ name: Validate
 on:
   pull_request:
     branches: [main]
-
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,8 @@ jobs:
         run: USER=$(/usr/bin/id -run) && chown -R $USER ./
       - name: Setup node
         uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Generate version
         run: npm run export-version
 
-      - name: Check that linting succeeds
+      - name: Lint
         run: npm run lint
 
-      - name: Check that build succeeds
+      - name: Build
         run: npm run build
 
-      - name: Run unit tests
+      - name: Tests
         run: npm test
 
-      # - name: Report test coverage
+      # - name: Coverage
       #   uses: ArtiomTr/jest-coverage-report-action@v2.2.2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,5 @@
 name: Validate
+# Lints, builds, and tests the project whenever a pull request is opened or merged
 
 on:
   pull_request:
@@ -15,8 +16,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Own all files
-        run: USER=$(/usr/bin/id -run) && chown -R $USER ./
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,8 @@ jobs:
         DOCKER: true
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Own all files
         run: USER=$(/usr/bin/id -run) && chown -R $USER ./

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    container:
-      image: node:18.17.0
-      env:
-        DOCKER: true
 
     steps:
       - name: Checkout repository
@@ -20,6 +16,8 @@ jobs:
 
       - name: Own all files
         run: USER=$(/usr/bin/id -run) && chown -R $USER ./
+      - name: Setup node
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Node
         uses: actions/setup-node@v3

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node
+      - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: 'npm'
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Check versions Match
+      - name: Check versions match
         run: npm run release

--- a/.github/workflows/versions-match.yml
+++ b/.github/workflows/versions-match.yml
@@ -1,4 +1,4 @@
-name: Check Versions Match
+name: Check versions match
 
 # On PR to main, check that package.json and package-lock.json share the version, and that CHANGELOG.md is spec-compliant. Block otherwise.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded to node 20 LTS
-- Use Vitest instead of Jest for forward compatibility with ESM.
+- Use Vitest instead of Jest for forward compatibility with ESM
 - Simplified TypeScript build settings and followed @typescript-eslint standards
 - Simplified Eslint settings
 - Package lockfile to version 3
+- Revamped GitHub workflows
 
 ### Fixed
 


### PR DESCRIPTION
## Changed
- Renamed Test workflow to Validate to better represent all the steps besides testing
- All workflows to use `checkout@v4` instead of `v3`
- Validate workflow to use `setup-node` instead of Docker container
- All `setup-node` steps to use `.nvmrc` to define node version
- Validate workflow to run on push to main as well as pull request

## Removed
- "own all files" step from Validate workflow