### PR TITLE
Add support for x.com links in fxtwitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified TypeScript build settings and followed @typescript-eslint standards
 - Simplified Eslint settings
 - Package lockfile to version 3
+- "Fix Twitter Links" to support alternative x.com links
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Tracks a statistic for the issuer. Use the `track` subcommand to begin tracking,
 
 You can find these in Discord by invoking the context menu (right-clicking) on any message in any channel where you're allowed to run commands.
 
-### Fix Twitter Links
+### Fix Twitter/X Links
 
-Transforms [twitter.com](https://twitter.com/) links in the given message to [FixTweet](https://github.com/FixTweet/FixTweet) links in an ephemeral reply. Please use fxtwitter in your own messages, especially when the tweet is a video. Twitter's default embed stinks on some platforms.
+Transforms [twitter.com](https://twitter.com/) and [x.com](https://x.com/) links in the given message to [FxTweet/FixupX](https://github.com/FixTweet/FxTwitter) links in an ephemeral reply. Please use fxtwitter/fixupx in your own messages, especially when the tweet is a video. The default embed stinks on some platforms.
 
 ### Talk
 

--- a/src/commands/contextMenu/fxtwitter.test.ts
+++ b/src/commands/contextMenu/fxtwitter.test.ts
@@ -13,6 +13,8 @@ describe('Fix Twitter Links', () => {
 			},
 			replyPrivately: mockReplyPrivately,
 		} as unknown as MessageContextMenuCommandContext;
+
+		mockReplyPrivately.mockClear();
 	});
 
 	test.each`
@@ -21,6 +23,8 @@ describe('Fix Twitter Links', () => {
 		${'example.com'}
 		${'twitter.com'}
 		${'fxtwitter.com'}
+		${'x.com'}
+		${'fixupx.com'}
 		${'foo/bar'}
 		${'file://foo/bar'}
 	`(
@@ -35,9 +39,10 @@ describe('Fix Twitter Links', () => {
 	test.each`
 		content
 		${'https://fxtwitter.com/example'}
+		${'https://fixupx.com/example'}
 		${'https://example.com'}
 	`(
-		'complains at the caller if none of the links in the message are Twitter links',
+		'complains at the caller if none of the links in the message are Twitter/X links',
 		async ({ content }: { content: string }) => {
 			context.targetMessage.content = content;
 
@@ -48,8 +53,9 @@ describe('Fix Twitter Links', () => {
 	test.each`
 		content                          | result
 		${'https://twitter.com/example'} | ${'https://fxtwitter.com/example'}
+		${'https://x.com/example'}       | ${'https://fixupx.com/example'}
 	`(
-		'sends an ephemeral message containing fixed versions of the Twitter links in the target',
+		'sends an ephemeral message containing fixed versions of the Twitter/X links in the target',
 		async ({ content, result }: { content: string; result: string }) => {
 			context.targetMessage.content = content;
 

--- a/src/commands/contextMenu/fxtwitter.ts
+++ b/src/commands/contextMenu/fxtwitter.ts
@@ -2,8 +2,14 @@ import { ApplicationCommandType, ContextMenuCommandBuilder } from 'discord.js';
 import { positionsOfUriInText } from '../../helpers/positionsOfUriInText';
 import { URL } from 'node:url';
 
+const twitter = 'twitter.com';
+const twitterPermutations = new Set([twitter, `www.${twitter}`]);
+
+const x = 'x.com';
+const xPermutations = new Set([x, `www.${x}`]);
+
 export const fxtwitter: MessageContextMenuCommand = {
-	info: new ContextMenuCommandBuilder().setName('Fix Twitter Links'),
+	info: new ContextMenuCommandBuilder().setName('Fix Twitter/X Links'),
 	type: ApplicationCommandType.Message,
 	requiresGuild: false,
 	async execute({ targetMessage, replyPrivately }) {
@@ -18,9 +24,7 @@ export const fxtwitter: MessageContextMenuCommand = {
 		for (const { start, end } of urlRanges) {
 			try {
 				const url = new URL(content.slice(start, end));
-				const twitter = 'twitter.com';
-				const permutations = [twitter, `www.${twitter}`];
-				if (permutations.includes(url.hostname)) {
+				if (twitterPermutations.has(url.hostname) || xPermutations.has(url.hostname)) {
 					urls.push(url);
 				}
 			} catch {
@@ -29,19 +33,23 @@ export const fxtwitter: MessageContextMenuCommand = {
 		}
 
 		if (urls.length === 0) {
-			throw new Error('There were no Twitter URLs found in the message.');
+			throw new Error('There were no Twitter/X URLs found in the message.');
 		}
 
 		// Print each fixed link in an ephemeral message, separated by newlines
 		await replyPrivately(
 			urls
-				.map(vxTwitter)
+				.map(fixLink)
 				.map(url => url.href)
 				.join('\n')
 		);
 	},
 };
 
-function vxTwitter(og: URL): URL {
-	return new URL(og.pathname, 'https://fxtwitter.com');
+function fixLink(og: URL): URL {
+	if (twitterPermutations.has(og.hostname)) {
+		return new URL(og.pathname, 'https://fxtwitter.com');
+	}
+	// else if (xPermutations.has(og.hostname))
+	return new URL(og.pathname, 'https://fixupx.com');
 }

--- a/src/commands/contextMenu/fxtwitter.ts
+++ b/src/commands/contextMenu/fxtwitter.ts
@@ -22,13 +22,9 @@ export const fxtwitter: MessageContextMenuCommand = {
 
 		const urls: Array<URL> = [];
 		for (const { start, end } of urlRanges) {
-			try {
-				const url = new URL(content.slice(start, end));
-				if (twitterPermutations.has(url.hostname) || xPermutations.has(url.hostname)) {
-					urls.push(url);
-				}
-			} catch {
-				continue; // Not actually a URL, so skip to the next one
+			const url = new URL(content.slice(start, end));
+			if (twitterPermutations.has(url.hostname) || xPermutations.has(url.hostname)) {
+				urls.push(url);
 			}
 		}
 

--- a/src/commands/contextMenu/fxtwitter.ts
+++ b/src/commands/contextMenu/fxtwitter.ts
@@ -10,7 +10,7 @@ export const fxtwitter: MessageContextMenuCommand = {
 		const content = targetMessage.content;
 
 		const urlRanges = positionsOfUriInText(content);
-		if (urlRanges === null) {
+		if (urlRanges.length === 0) {
 			throw new Error('There were no URLs found in the message.');
 		}
 

--- a/src/helpers/positionsOfUriInText.test.ts
+++ b/src/helpers/positionsOfUriInText.test.ts
@@ -6,10 +6,10 @@ import { positionsOfUriInText } from './positionsOfUriInText';
 describe('Identifying URIs in strings', () => {
 	test.each`
 		msg                                                            | ranges
-		${''}                                                          | ${null}
-		${'nothing'}                                                   | ${null}
-		${'still nothing'}                                             | ${null}
-		${'https://nope'}                                              | ${null}
+		${''}                                                          | ${[]}
+		${'nothing'}                                                   | ${[]}
+		${'still nothing'}                                             | ${[]}
+		${'https://nope'}                                              | ${[]}
 		${'https://yep.com'}                                           | ${[{ start: 0, end: 15 }]}
 		${'https://yep.com at the start'}                              | ${[{ start: 0, end: 15 }]}
 		${'at the end https://yep.com'}                                | ${[{ start: 11, end: 26 }]}
@@ -21,7 +21,7 @@ describe('Identifying URIs in strings', () => {
 		${'https://yep.com https://yep.com then https://yep.com ends'} | ${[{ start: 0, end: 15 }, { start: 16, end: 31 }, { start: 37, end: 52 }]}
 	`(
 		"correctly identifies URI substring range(s) in string '$msg'",
-		({ msg, ranges }: { msg: string; ranges: NonEmptyArray<Range> | null }) => {
+		({ msg, ranges }: { msg: string; ranges: Array<Range> | null }) => {
 			expect(positionsOfUriInText(msg)).toStrictEqual(ranges);
 		}
 	);

--- a/src/helpers/positionsOfUriInText.ts
+++ b/src/helpers/positionsOfUriInText.ts
@@ -1,24 +1,32 @@
+import { URL } from 'node:url';
+
 export interface Range {
 	start: number;
 	end: number;
 }
+
+const uriRegex =
+	/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gu;
 
 /**
  * Returns an array of index positions in the given string that may
  * encapsulate URLs, or `null` if no URLs were found.
  */
 export function positionsOfUriInText(str: string): Array<Range> {
-	const uri =
-		/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gu;
-
 	const results: Array<Range> = [];
 	let match: RegExpExecArray | null = null;
 
-	while ((match = uri.exec(str))) {
+	while ((match = uriRegex.exec(str))) {
 		const range: Range = {
 			start: match.index,
 			end: match.index + match[0].length,
 		};
+
+		// Just in case the regex returns a match that is not a valid URI
+		if (!URL.canParse(match[0])) {
+			continue;
+		}
+
 		results.push(range);
 	}
 

--- a/src/helpers/positionsOfUriInText.ts
+++ b/src/helpers/positionsOfUriInText.ts
@@ -7,23 +7,19 @@ export interface Range {
  * Returns an array of index positions in the given string that may
  * encapsulate URLs, or `null` if no URLs were found.
  */
-export function positionsOfUriInText(str: string): NonEmptyArray<Range> | null {
+export function positionsOfUriInText(str: string): Array<Range> {
 	const uri =
 		/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gu;
 
-	let results: NonEmptyArray<Range> | null = null;
+	const results: Array<Range> = [];
 	let match: RegExpExecArray | null = null;
 
 	while ((match = uri.exec(str))) {
 		const range: Range = {
 			start: match.index,
-			end: match.index + (match[0]?.length ?? 0),
+			end: match.index + match[0].length,
 		};
-		if (!results) {
-			results = [range];
-		} else {
-			results.push(range);
-		}
+		results.push(range);
 	}
 
 	return results;


### PR DESCRIPTION
### Added
- Support for converting `x.com` links to `fixupx.com` (see the updated [FxTwitter](https://github.com/FixTweet/FxTwitter))

### Fixed
- Missing code coverage in `positionsOfUriInText` by making it return an empty array instead of null when there are no matches
- Missing code coverage in `fxtwitter.ts` by moving URL-parsing error checking to `positionsOfUriInText` and checking what happens if the uri regex matches an invalid URI