### PR TITLE
Resolve vite and uuid vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7974,13 +7974,16 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
 			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7231,9 +7231,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-			"integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+			"integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.18.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@types/tmp": "0.2.3",
 				"@typescript-eslint/eslint-plugin": "5.56.0",
 				"@typescript-eslint/parser": "5.56.0",
-				"@vitest/coverage-istanbul": "0.34.2",
+				"@vitest/coverage-istanbul": "1.2.1",
 				"eslint": "8.36.0",
 				"eslint-config-prettier": "8.8.0",
 				"eslint-config-strictest": "0.7.0",
@@ -49,7 +49,7 @@
 				"semver": "7.5.4",
 				"ts-node": "10.9.1",
 				"typescript": "4.9.5",
-				"vitest": "0.34.2",
+				"vitest": "1.2.1",
 				"vitest-mock-extended": "1.3.1"
 			},
 			"engines": {
@@ -163,34 +163,34 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-			"integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
-			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.10",
-				"@babel/generator": "^7.22.10",
-				"@babel/helper-compilation-targets": "^7.22.10",
-				"@babel/helper-module-transforms": "^7.22.9",
-				"@babel/helpers": "^7.22.10",
-				"@babel/parser": "^7.22.10",
-				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.10",
-				"@babel/types": "^7.22.10",
-				"convert-source-map": "^1.7.0",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.23.7",
+				"@babel/parser": "^7.23.6",
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.2",
+				"json5": "^2.2.3",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -226,14 +226,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-			"integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.5",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -285,28 +285,28 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-			"integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-			"integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
 				"@babel/helper-simple-access": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/helper-validator-identifier": "^7.22.5"
+				"@babel/helper-validator-identifier": "^7.22.20"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -358,23 +358,23 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-			"integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
-			"integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.10",
-				"@babel/types": "^7.22.10"
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -664,6 +664,374 @@
 				"node": ">=16.9.0"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+			"integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+			"integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+			"integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+			"integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz",
+			"integrity": "sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+			"integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+			"integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+			"integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+			"integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+			"integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+			"integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+			"integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+			"integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+			"integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+			"integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+			"integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+			"integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+			"integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+			"integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+			"integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+			"integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+			"integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+			"integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -821,9 +1189,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -1130,6 +1498,175 @@
 			"integrity": "sha512-0ZBIrOQ3Glr4l7l/ehu+nl8EzJ/FgqNjlhVodEWCk649DVeb7+czOrpCDv+DJO3uU9Xai4mBQ5TifzYzGsndNQ==",
 			"dev": true
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
+			"integrity": "sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.5.tgz",
+			"integrity": "sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz",
+			"integrity": "sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.5.tgz",
+			"integrity": "sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.5.tgz",
+			"integrity": "sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.5.tgz",
+			"integrity": "sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.5.tgz",
+			"integrity": "sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.5.tgz",
+			"integrity": "sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+			"integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.5.tgz",
+			"integrity": "sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.5.tgz",
+			"integrity": "sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.5.tgz",
+			"integrity": "sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.5.tgz",
+			"integrity": "sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@sapphire/async-queue": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
@@ -1202,20 +1739,11 @@
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
 			"dev": true
 		},
-		"node_modules/@types/chai": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
-			"integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+		"node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
-		},
-		"node_modules/@types/chai-subset": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-			"integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
-			"dev": true,
-			"dependencies": {
-				"@types/chai": "*"
-			}
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.12",
@@ -1586,47 +2114,50 @@
 			}
 		},
 		"node_modules/@vitest/coverage-istanbul": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-0.34.2.tgz",
-			"integrity": "sha512-rf6nY80ieYDGBg+50Sm1XTeYkrAF2sJu3pqL4IddBakxddTNUjEWY90Bv3LvspII6Bd/fiVcestozShQ/NVDtQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-1.2.1.tgz",
+			"integrity": "sha512-j8M4R3XbQ7cmLqJd7mfxCpEc0bQ7S6o5VIEt7c0Auri2lT1hkd89Sa/mOYDnuGasTNawamW+0d9vDRK/5uhVXw==",
 			"dev": true,
 			"dependencies": {
-				"istanbul-lib-coverage": "^3.2.0",
-				"istanbul-lib-instrument": "^6.0.0",
+				"debug": "^4.3.4",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-instrument": "^6.0.1",
 				"istanbul-lib-report": "^3.0.1",
 				"istanbul-lib-source-maps": "^4.0.1",
-				"istanbul-reports": "^3.1.5",
+				"istanbul-reports": "^3.1.6",
+				"magicast": "^0.3.3",
+				"picocolors": "^1.0.0",
 				"test-exclude": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": ">=0.32.0 <1"
+				"vitest": "^1.0.0"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.2.tgz",
-			"integrity": "sha512-EZm2dMNlLyIfDMha17QHSQcg2KjeAZaXd65fpPzXY5bvnfx10Lcaz3N55uEe8PhF+w4pw+hmrlHLLlRn9vkBJg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.1.tgz",
+			"integrity": "sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "0.34.2",
-				"@vitest/utils": "0.34.2",
-				"chai": "^4.3.7"
+				"@vitest/spy": "1.2.1",
+				"@vitest/utils": "1.2.1",
+				"chai": "^4.3.10"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.2.tgz",
-			"integrity": "sha512-8ydGPACVX5tK3Dl0SUwxfdg02h+togDNeQX3iXVFYgzF5odxvaou7HnquALFZkyVuYskoaHUOqOyOLpOEj5XTA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.1.tgz",
+			"integrity": "sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "0.34.2",
-				"p-limit": "^4.0.0",
+				"@vitest/utils": "1.2.1",
+				"p-limit": "^5.0.0",
 				"pathe": "^1.1.1"
 			},
 			"funding": {
@@ -1634,15 +2165,15 @@
 			}
 		},
 		"node_modules/@vitest/runner/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+			"integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
 			"dev": true,
 			"dependencies": {
 				"yocto-queue": "^1.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -1661,52 +2192,41 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.2.tgz",
-			"integrity": "sha512-qhQ+xy3u4mwwLxltS4Pd4SR+XHv4EajiTPNY3jkIBLUApE6/ce72neJPSUQZ7bL3EBuKI+NhvzhGj3n5baRQUQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.1.tgz",
+			"integrity": "sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==",
 			"dev": true,
 			"dependencies": {
-				"magic-string": "^0.30.1",
+				"magic-string": "^0.30.5",
 				"pathe": "^1.1.1",
-				"pretty-format": "^29.5.0"
+				"pretty-format": "^29.7.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/snapshot/node_modules/magic-string": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-			"integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@vitest/spy": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.2.tgz",
-			"integrity": "sha512-yd4L9OhfH6l0Av7iK3sPb3MykhtcRN5c5K5vm1nTbuN7gYn+yvUVVsyvzpHrjqS7EWqn9WsPJb7+0c3iuY60tA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.1.tgz",
+			"integrity": "sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==",
 			"dev": true,
 			"dependencies": {
-				"tinyspy": "^2.1.1"
+				"tinyspy": "^2.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.2.tgz",
-			"integrity": "sha512-Lzw+kAsTPubhoQDp1uVAOP6DhNia1GMDsI9jgB0yMn+/nDaPieYQ88lKqz/gGjSHL4zwOItvpehec9OY+rS73w==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.1.tgz",
+			"integrity": "sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==",
 			"dev": true,
 			"dependencies": {
-				"diff-sequences": "^29.4.3",
-				"loupe": "^2.3.6",
-				"pretty-format": "^29.5.0"
+				"diff-sequences": "^29.6.3",
+				"estree-walker": "^3.0.3",
+				"loupe": "^2.3.7",
+				"pretty-format": "^29.7.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -1719,9 +2239,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1740,9 +2260,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -2117,9 +2637,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.10",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -2136,10 +2656,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001517",
-				"electron-to-chromium": "^1.4.477",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.11"
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2221,9 +2741,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001521",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-			"integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
+			"version": "1.0.30001579",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2246,18 +2766,18 @@
 			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
 		},
 		"node_modules/chai": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^4.1.2",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
+				"type-detect": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=4"
@@ -2286,10 +2806,13 @@
 			"dev": true
 		},
 		"node_modules/check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
 			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
 			"engines": {
 				"node": "*"
 			}
@@ -2502,9 +3025,9 @@
 			}
 		},
 		"node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
 		"node_modules/create-require": {
@@ -2726,9 +3249,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.496",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.496.tgz",
-			"integrity": "sha512-qeXC3Zbykq44RCrBa4kr8v/dWzYJA8rAwpyh9Qd+NKWoJfjG5vvJqy9XOJ9H4P/lqulZBCgUWAYi+FeK5AuJ8g==",
+			"version": "1.4.640",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.640.tgz",
+			"integrity": "sha512-z/6oZ/Muqk4BaE7P69bXhUhpJbUM9ZJeka43ZwxsDshKtePns4mhBlh8bU5+yrnOnz3fhG82XLzGUXazOmsWnA==",
 			"dev": true
 		},
 		"node_modules/emitter-listener": {
@@ -2860,6 +3383,44 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
+			"integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.19.11",
+				"@esbuild/android-arm": "0.19.11",
+				"@esbuild/android-arm64": "0.19.11",
+				"@esbuild/android-x64": "0.19.11",
+				"@esbuild/darwin-arm64": "0.19.11",
+				"@esbuild/darwin-x64": "0.19.11",
+				"@esbuild/freebsd-arm64": "0.19.11",
+				"@esbuild/freebsd-x64": "0.19.11",
+				"@esbuild/linux-arm": "0.19.11",
+				"@esbuild/linux-arm64": "0.19.11",
+				"@esbuild/linux-ia32": "0.19.11",
+				"@esbuild/linux-loong64": "0.19.11",
+				"@esbuild/linux-mips64el": "0.19.11",
+				"@esbuild/linux-ppc64": "0.19.11",
+				"@esbuild/linux-riscv64": "0.19.11",
+				"@esbuild/linux-s390x": "0.19.11",
+				"@esbuild/linux-x64": "0.19.11",
+				"@esbuild/netbsd-x64": "0.19.11",
+				"@esbuild/openbsd-x64": "0.19.11",
+				"@esbuild/sunos-x64": "0.19.11",
+				"@esbuild/win32-arm64": "0.19.11",
+				"@esbuild/win32-ia32": "0.19.11",
+				"@esbuild/win32-x64": "0.19.11"
 			}
 		},
 		"node_modules/escalade": {
@@ -3432,6 +3993,15 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3446,6 +4016,68 @@
 			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
 			"integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
 			"dev": true
+		},
+		"node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -3776,6 +4408,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-symbol-description": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -4065,6 +4709,15 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -4404,6 +5057,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -4486,18 +5151,18 @@
 			"dev": true
 		},
 		"node_modules/istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/istanbul-lib-instrument": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.0.tgz",
-			"integrity": "sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+			"integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.12.3",
@@ -4709,10 +5374,14 @@
 			"dev": true
 		},
 		"node_modules/local-pkg": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
-			"integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+			"integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
 			"dev": true,
+			"dependencies": {
+				"mlly": "^1.4.2",
+				"pkg-types": "^1.0.3"
+			},
 			"engines": {
 				"node": ">=14"
 			},
@@ -4777,12 +5446,12 @@
 			}
 		},
 		"node_modules/loupe": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
 			"dev": true,
 			"dependencies": {
-				"get-func-name": "^2.0.0"
+				"get-func-name": "^2.0.1"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -4792,6 +5461,29 @@
 			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.3.tgz",
+			"integrity": "sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.23.6",
+				"@babel/types": "^7.23.6",
+				"source-map-js": "^1.0.2"
 			}
 		},
 		"node_modules/make-dir": {
@@ -4813,6 +5505,12 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
 		"node_modules/merge2": {
@@ -4909,15 +5607,15 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-			"integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
+			"integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.9.0",
-				"pathe": "^1.1.1",
+				"acorn": "^8.11.3",
+				"pathe": "^1.1.2",
 				"pkg-types": "^1.0.3",
-				"ufo": "^1.1.2"
+				"ufo": "^1.3.2"
 			}
 		},
 		"node_modules/module-details-from-path": {
@@ -5003,9 +5701,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"node_modules/nodemon": {
@@ -5109,6 +5807,33 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
+			"integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/nssocket": {
@@ -5444,9 +6169,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-			"integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
 			"dev": true
 		},
 		"node_modules/pathval": {
@@ -6218,6 +6943,38 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rollup": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
+			"integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "1.0.5"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.9.5",
+				"@rollup/rollup-android-arm64": "4.9.5",
+				"@rollup/rollup-darwin-arm64": "4.9.5",
+				"@rollup/rollup-darwin-x64": "4.9.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.9.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.9.5",
+				"@rollup/rollup-linux-arm64-musl": "4.9.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-musl": "4.9.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.9.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.9.5",
+				"@rollup/rollup-win32-x64-msvc": "4.9.5",
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6567,9 +7324,9 @@
 			"dev": true
 		},
 		"node_modules/std-env": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.4.0.tgz",
-			"integrity": "sha512-YqHeQIIQ8r1VtUZOTOyjsAXAsjr369SplZ5rlQaiJTBsvodvPSCME7vuz8pnQltbQ0Cw0lyFo5Q8uyNwYQ58Xw==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+			"integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
 			"dev": true
 		},
 		"node_modules/string_decoder": {
@@ -6635,6 +7392,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strip-indent": {
@@ -6769,24 +7538,24 @@
 			"dev": true
 		},
 		"node_modules/tinybench": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
-			"integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
+			"integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
 			"dev": true
 		},
 		"node_modules/tinypool": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
-			"integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.2.tgz",
+			"integrity": "sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-			"integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+			"integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -7109,9 +7878,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz",
-			"integrity": "sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
 			"dev": true
 		},
 		"node_modules/unbox-primitive": {
@@ -7161,9 +7930,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"dev": true,
 			"funding": [
 				{
@@ -7231,29 +8000,29 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-			"integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+			"integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.18.10",
-				"postcss": "^8.4.27",
-				"rollup": "^3.27.1"
+				"esbuild": "^0.19.3",
+				"postcss": "^8.4.32",
+				"rollup": "^4.2.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
 			},
 			"optionalDependencies": {
-				"fsevents": "~2.3.2"
+				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": ">= 14",
+				"@types/node": "^18.0.0 || >=20.0.0",
 				"less": "*",
 				"lightningcss": "^1.21.0",
 				"sass": "*",
@@ -7286,149 +8055,77 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.2.tgz",
-			"integrity": "sha512-JtW249Zm3FB+F7pQfH56uWSdlltCo1IOkZW5oHBzeQo0iX4jtC7o1t9aILMGd9kVekXBP2lfJBEQt9rBh07ebA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.1.tgz",
+			"integrity": "sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.3.4",
-				"mlly": "^1.4.0",
 				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"vite": "^3.0.0 || ^4.0.0"
+				"vite": "^5.0.0"
 			},
 			"bin": {
 				"vite-node": "vite-node.mjs"
 			},
 			"engines": {
-				"node": ">=v14.18.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.18.20",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.18.20",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.18.20",
-				"@esbuild/android-arm64": "0.18.20",
-				"@esbuild/android-x64": "0.18.20",
-				"@esbuild/darwin-arm64": "0.18.20",
-				"@esbuild/darwin-x64": "0.18.20",
-				"@esbuild/freebsd-arm64": "0.18.20",
-				"@esbuild/freebsd-x64": "0.18.20",
-				"@esbuild/linux-arm": "0.18.20",
-				"@esbuild/linux-arm64": "0.18.20",
-				"@esbuild/linux-ia32": "0.18.20",
-				"@esbuild/linux-loong64": "0.18.20",
-				"@esbuild/linux-mips64el": "0.18.20",
-				"@esbuild/linux-ppc64": "0.18.20",
-				"@esbuild/linux-riscv64": "0.18.20",
-				"@esbuild/linux-s390x": "0.18.20",
-				"@esbuild/linux-x64": "0.18.20",
-				"@esbuild/netbsd-x64": "0.18.20",
-				"@esbuild/openbsd-x64": "0.18.20",
-				"@esbuild/sunos-x64": "0.18.20",
-				"@esbuild/win32-arm64": "0.18.20",
-				"@esbuild/win32-ia32": "0.18.20",
-				"@esbuild/win32-x64": "0.18.20"
-			}
-		},
-		"node_modules/vite/node_modules/rollup": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
-			"integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
-			"dev": true,
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
 		"node_modules/vitest": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.2.tgz",
-			"integrity": "sha512-WgaIvBbjsSYMq/oiMlXUI7KflELmzM43BEvkdC/8b5CAod4ryAiY2z8uR6Crbi5Pjnu5oOmhKa9sy7uk6paBxQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.1.tgz",
+			"integrity": "sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==",
 			"dev": true,
 			"dependencies": {
-				"@types/chai": "^4.3.5",
-				"@types/chai-subset": "^1.3.3",
-				"@types/node": "*",
-				"@vitest/expect": "0.34.2",
-				"@vitest/runner": "0.34.2",
-				"@vitest/snapshot": "0.34.2",
-				"@vitest/spy": "0.34.2",
-				"@vitest/utils": "0.34.2",
-				"acorn": "^8.9.0",
-				"acorn-walk": "^8.2.0",
+				"@vitest/expect": "1.2.1",
+				"@vitest/runner": "1.2.1",
+				"@vitest/snapshot": "1.2.1",
+				"@vitest/spy": "1.2.1",
+				"@vitest/utils": "1.2.1",
+				"acorn-walk": "^8.3.2",
 				"cac": "^6.7.14",
-				"chai": "^4.3.7",
+				"chai": "^4.3.10",
 				"debug": "^4.3.4",
-				"local-pkg": "^0.4.3",
-				"magic-string": "^0.30.1",
+				"execa": "^8.0.1",
+				"local-pkg": "^0.5.0",
+				"magic-string": "^0.30.5",
 				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"std-env": "^3.3.3",
-				"strip-literal": "^1.0.1",
-				"tinybench": "^2.5.0",
-				"tinypool": "^0.7.0",
-				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.34.2",
+				"std-env": "^3.5.0",
+				"strip-literal": "^1.3.0",
+				"tinybench": "^2.5.1",
+				"tinypool": "^0.8.1",
+				"vite": "^5.0.0",
+				"vite-node": "1.2.1",
 				"why-is-node-running": "^2.2.2"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": ">=v14.18.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@vitest/browser": "*",
-				"@vitest/ui": "*",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"@vitest/browser": "^1.0.0",
+				"@vitest/ui": "^1.0.0",
 				"happy-dom": "*",
-				"jsdom": "*",
-				"playwright": "*",
-				"safaridriver": "*",
-				"webdriverio": "*"
+				"jsdom": "*"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/node": {
 					"optional": true
 				},
 				"@vitest/browser": {
@@ -7441,15 +8138,6 @@
 					"optional": true
 				},
 				"jsdom": {
-					"optional": true
-				},
-				"playwright": {
-					"optional": true
-				},
-				"safaridriver": {
-					"optional": true
-				},
-				"webdriverio": {
 					"optional": true
 				}
 			}
@@ -7465,18 +8153,6 @@
 			"peerDependencies": {
 				"typescript": "3.x || 4.x || 5.x",
 				"vitest": ">=0.31.1"
-			}
-		},
-		"node_modules/vitest/node_modules/magic-string": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-			"integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/vizion": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@types/tmp": "0.2.3",
 		"@typescript-eslint/eslint-plugin": "5.56.0",
 		"@typescript-eslint/parser": "5.56.0",
-		"@vitest/coverage-istanbul": "0.34.2",
+		"@vitest/coverage-istanbul": "1.2.1",
 		"eslint": "8.36.0",
 		"eslint-config-prettier": "8.8.0",
 		"eslint-config-strictest": "0.7.0",
@@ -89,7 +89,7 @@
 		"semver": "7.5.4",
 		"ts-node": "10.9.1",
 		"typescript": "4.9.5",
-		"vitest": "0.34.2",
+		"vitest": "1.2.1",
 		"vitest-mock-extended": "1.3.1"
 	},
 	"overrides": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"vitest-mock-extended": "1.3.1"
 	},
 	"overrides": {
-		"axios": "^1.6.5"
+		"axios": "1.6.5",
+		"uuid": "9.0.1"
 	}
 }

--- a/src/commands/__snapshots__/toTheGallows.test.ts.snap
+++ b/src/commands/__snapshots__/toTheGallows.test.ts.snap
@@ -6,7 +6,7 @@ exports[`toTheGallows > specifying length and number of guesses always puts the 
     {
       "inline": true,
       "name": "_ _",
-      "value": "\`\`\` /---\\\\
+      "value": "\`\`\` /---\\
      |
      |
      |

--- a/src/evilHangman/__snapshots__/evilHangmanAsciiArt.test.ts.snap
+++ b/src/evilHangman/__snapshots__/evilHangmanAsciiArt.test.ts.snap
@@ -2,31 +2,31 @@
 
 exports[`evilHangmanAsciiArt.ts > frame 0 of 1 has not changed 1`] = `
 "
- /---\\\\
+ /---\\
  o   |
-\\\\|/  |
+\\|/  |
  |   |
-/ \\\\  |
+/ \\  |
     -|-
 "
 `;
 
 exports[`evilHangmanAsciiArt.ts > frame 0 of 7 has not changed 1`] = `
 "
- /---\\\\
+ /---\\
  o   |
-\\\\|/  |
+\\|/  |
  |   |
-/ \\\\  |
+/ \\  |
     -|-
 "
 `;
 
 exports[`evilHangmanAsciiArt.ts > frame 3 of 7 has not changed 1`] = `
 "
- /---\\\\
+ /---\\
  o   |
-\\\\|/  |
+\\|/  |
      |
      |
     -|-
@@ -35,9 +35,9 @@ exports[`evilHangmanAsciiArt.ts > frame 3 of 7 has not changed 1`] = `
 
 exports[`evilHangmanAsciiArt.ts > frame 4 of 7 has not changed 1`] = `
 "
- /---\\\\
+ /---\\
  o   |
-\\\\|   |
+\\|   |
      |
      |
     -|-
@@ -45,7 +45,7 @@ exports[`evilHangmanAsciiArt.ts > frame 4 of 7 has not changed 1`] = `
 `;
 
 exports[`evilHangmanAsciiArt.ts > frame 7 of 7 has not changed 1`] = `
-" /---\\\\
+" /---\\
      |
      |
      |
@@ -56,9 +56,9 @@ exports[`evilHangmanAsciiArt.ts > frame 7 of 7 has not changed 1`] = `
 
 exports[`evilHangmanAsciiArt.ts > frame 50 of 1000 has not changed 1`] = `
 "
- /---\\\\
+ /---\\
  o   |
-\\\\|/  |
+\\|/  |
  |   |
 /    |
     -|-


### PR DESCRIPTION
### Changed
- All `vitest` dependencies to be up-to-date with post-1.0.0 release

### Fixed
- `vite` vulnerability by updating to 5.0.12
- `uuid` deprecation with 9.0.0 override