### PR TITLE
Fix dirname not defined bug

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
 import js from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
 // eslint-disable-next-line import/no-unresolved
-import typescriptParser from '@typescript-eslint/parser';
+import tsParser from '@typescript-eslint/parser';
 // eslint-disable-next-line import/no-unresolved
-import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import typescript from '@typescript-eslint/eslint-plugin';
 import deprecation from 'eslint-plugin-deprecation';
 import fileProgress from 'eslint-plugin-file-progress';
 import import_ from 'eslint-plugin-import';
@@ -102,19 +102,19 @@ export default [
 	{
 		files: ['**/*.{m,c,}ts{x,}'],
 		plugins: {
-			'@typescript-eslint': typescriptPlugin,
+			'@typescript-eslint': typescript,
 			deprecation: deprecation,
 		},
 		languageOptions: {
-			parser: typescriptParser,
+			parser: tsParser,
 			parserOptions: {
 				project: './tsconfig.eslint.json',
 			},
 		},
 		rules: {
 			// Recommended
-			...typescriptPlugin.configs['strict-type-checked'].rules,
-			...typescriptPlugin.configs['stylistic-type-checked'].rules,
+			...typescript.configs['strict-type-checked'].rules,
+			...typescript.configs['stylistic-type-checked'].rules,
 			...deprecation.configs.recommended.rules,
 
 			// Overrides

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,9 +1,5 @@
-import {
-	ChatInputCommandInteraction,
-	EmbedBuilder,
-	SlashCommandBuilder,
-	userMention,
-} from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { EmbedBuilder, SlashCommandBuilder, userMention } from 'discord.js';
 
 import { db } from '../database/index.js';
 import { sanitize } from '../helpers/sanitize.js';

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -1,5 +1,6 @@
 import type { AttachmentPayload } from 'discord.js';
 import { SlashCommandBuilder, ChannelType, PermissionFlagsBits } from 'discord.js';
+import type { AudioResource } from '@discordjs/voice';
 import {
 	createAudioResource,
 	createAudioPlayer,
@@ -9,7 +10,6 @@ import {
 	VoiceConnectionStatus,
 	NoSubscriberBehavior,
 	entersState,
-	AudioResource,
 } from '@discordjs/voice';
 import { say, Speaker } from 'dectalk';
 import { writeFileSync, createReadStream } from 'node:fs';

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -8,6 +8,8 @@ import type {
 	RepliableInteraction,
 } from 'discord.js';
 import { EmbedBuilder, Colors, ApplicationCommandType, ChannelType } from 'discord.js';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { allButtons } from '../buttons/index.js';
 import { allCommands } from '../commands/index.js';
@@ -21,6 +23,8 @@ import { logUser } from '../helpers/logUser.js';
 import { onEvent } from '../helpers/onEvent.js';
 import { UserMessageError } from '../helpers/UserMessageError.js';
 import { debug, error, warn } from '../logger.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * The event handler for Discord Interactions (usually chat commands)

--- a/src/helpers/NetworkError.ts
+++ b/src/helpers/NetworkError.ts
@@ -1,4 +1,5 @@
-import { describeCode, HttpStatusCode } from './HttpStatusCode.js';
+import type { HttpStatusCode } from './HttpStatusCode.js';
+import { describeCode } from './HttpStatusCode.js';
 
 /**
  * An object that represents an HTTP status returned from an API request.


### PR DESCRIPTION
This PR is mostly cleanup from the migration to ESM, pulling changes from #87 that I missed.

### Changed
- Renamed typescript plugins in eslint config to match others
- Caught more instances of explicit type imports

### Fixed
- `__dirname not defined` bug when privatizing error messages in `interactionCreate.ts`