### PR TITLE
Use new dectalk-tts package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project to use ESM instead of CommonJS
 - `package.json` to be sorted using `npx sort-package-json`
 - Release script to use `tsx` instead of `ts-node` to resolve ESM problems
+- `/talk` to use `dectalk-tts` package instead of `dectalk`
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:20-slim
 RUN apt update
 RUN apt upgrade --yes
 
-# Necessary for /talk Dectalk (Linux x86_64)
-RUN apt install libpulse0 --yes
-
 # Necessary for /update
 RUN apt install git --yes
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Tracks a statistic for the issuer. Use the `track` subcommand to begin tracking,
 
 ### /talk
 
-Uses the [dectalk](https://github.com/babakinha/dectalk) text-to-speech engine to speak the message you give it,
-either sending a .wav file in a text channel or talking out loud in a voice channel. Comes with 9 different voices.
+Uses the [dectalk](https://github.com/JstnMcBrd/dectalk-tts) text-to-speech engine to speak the message you give it, either sending a .wav file in a text channel or talking out loud in a voice channel. Comes with 9 different voices.
+
+By using this command, you are acknowleding that your input will be sent to a third-party web API, which may use your information however it wants. Please see [this disclaimer](https://github.com/JstnMcBrd/dectalk-tts#about).
 
 ### /tothegallows
 
@@ -135,12 +136,6 @@ This project requires [NodeJS](https://nodejs.org/) (version 18.17 or later) and
 $ node -v && npm -v
 v18.17.1
 9.6.7
-```
-
-If you are using Linux, you will also need to install the following package to use the `/talk` command:
-
-```sh
-$ apt install libpulse0
 ```
 
 If you don't want to install Node or any other dependencies on your machine, you may also use [Docker](https://www.docker.com/). Docker runs the project in a lightweight virtual Linux environment will all dependencies pre-installed, so functionality will be identical on any operating system.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,16 @@ export default [
 		},
 	},
 
+	// Import has problems with dectalk-tts package
+	{
+		files: ['**/commands/talk.ts'],
+		rules: {
+			'import/default': 0,
+			'import/no-named-as-default': 0,
+			'import/no-named-as-default-member': 0,
+		},
+	},
+
 	// TypeScript
 	{
 		files: ['**/*.{m,c,}ts{x,}'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
 				"@prisma/client": "4.3.1",
-				"dectalk": "1.3.1",
+				"dectalk-tts": "1.0.0",
 				"discord.js": "14.9.0",
 				"dotenv": "16.0.3",
 				"ffmpeg-static": "5.1.0",
@@ -3115,12 +3115,12 @@
 				}
 			}
 		},
-		"node_modules/dectalk": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/dectalk/-/dectalk-1.3.1.tgz",
-			"integrity": "sha512-5rriTMO7HfGGyMEQfMaQGIJpl6zNyjHWmVJjdkylxEUneQsWIJchVktas7/MRa2BXaYy4h4wT/EUh4hchLir2w==",
-			"dependencies": {
-				"tmp": "^0.2.1"
+		"node_modules/dectalk-tts": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dectalk-tts/-/dectalk-tts-1.0.0.tgz",
+			"integrity": "sha512-aVlyUR02pKoUVPGhl7Lz5hqd7/eQRA309ZFiB7E+9HtzpQVPyhhwqkPv/k0Zv0oohgFTboatg8ZmBFhKZ5ONKQ==",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/deep-eql": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
 				"@prisma/client": "4.3.1",
-				"dectalk-tts": "1.0.0",
+				"dectalk-tts": "1.0.1",
 				"discord.js": "14.9.0",
 				"dotenv": "16.0.3",
 				"ffmpeg-static": "5.1.0",
@@ -3116,9 +3116,9 @@
 			}
 		},
 		"node_modules/dectalk-tts": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dectalk-tts/-/dectalk-tts-1.0.0.tgz",
-			"integrity": "sha512-aVlyUR02pKoUVPGhl7Lz5hqd7/eQRA309ZFiB7E+9HtzpQVPyhhwqkPv/k0Zv0oohgFTboatg8ZmBFhKZ5ONKQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dectalk-tts/-/dectalk-tts-1.0.1.tgz",
+			"integrity": "sha512-IyBhRbveEyWg7ENXu+y/0Ni6gl94iBb5JE4zx8+mNcLfPFvIhMxKBVQiXkewTjqNJEu4Gq4x7Hu93L0m6gMKFg==",
 			"engines": {
 				"node": ">=18"
 			}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"@discordjs/voice": "0.15.0",
 		"@prisma/client": "4.3.1",
-		"dectalk-tts": "1.0.0",
+		"dectalk-tts": "1.0.1",
 		"discord.js": "14.9.0",
 		"dotenv": "16.0.3",
 		"ffmpeg-static": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"@discordjs/voice": "0.15.0",
 		"@prisma/client": "4.3.1",
-		"dectalk": "1.3.1",
+		"dectalk-tts": "1.0.0",
 		"discord.js": "14.9.0",
 		"dotenv": "16.0.3",
 		"ffmpeg-static": "5.1.0",

--- a/src/commands/contextMenu/talk.test.ts
+++ b/src/commands/contextMenu/talk.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 // Mock the talkMessage functionality
-const mockSpeak = vi.hoisted(() => vi.fn());
+const speakMock = vi.hoisted(() => vi.fn());
 vi.mock('../talk.js', () => ({
-	speak: mockSpeak,
+	speak: speakMock,
 }));
 
 // Mock the logger so nothing is printed
@@ -27,6 +27,6 @@ describe('Talk Context Menu Command', () => {
 	// we don't actually have to test much.
 	test('Calls the talkMessage method of the talk slash command', async () => {
 		await expect(talk.execute(context)).resolves.toBeUndefined();
-		expect(mockSpeak).toHaveBeenCalledOnce();
+		expect(speakMock).toHaveBeenCalledOnce();
 	});
 });

--- a/src/commands/contextMenu/talk.ts
+++ b/src/commands/contextMenu/talk.ts
@@ -9,6 +9,6 @@ export const talk: MessageContextMenuCommand = {
 	type: ApplicationCommandType.Message,
 	requiresGuild: false,
 	async execute(context) {
-		await speak(context, context.targetMessage.content, undefined);
+		await speak(context, context.targetMessage.content);
 	},
 };

--- a/src/commands/contextMenu/talk.ts
+++ b/src/commands/contextMenu/talk.ts
@@ -9,6 +9,6 @@ export const talk: MessageContextMenuCommand = {
 	type: ApplicationCommandType.Message,
 	requiresGuild: false,
 	async execute(context) {
-		await speak(context.targetMessage.content, undefined, context);
+		await speak(context, context.targetMessage.content, undefined);
 	},
 };

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -4,7 +4,7 @@ import { ChannelType } from 'discord.js';
 
 // Overwrite dectalk say method
 const dectalkMock = vi.hoisted(() => vi.fn());
-vi.mock('dectalk-tts', async () => ({ default: dectalkMock }));
+vi.mock('dectalk-tts', () => ({ default: dectalkMock }));
 
 // Mock the logger so nothing is printed
 vi.mock('../logger');
@@ -13,7 +13,7 @@ vi.mock('../logger');
 import { talk } from './talk.js';
 
 describe('Talk Slash Command', () => {
-	const speakerMock = vi.fn();
+	const speakerMock = vi.fn<[], string | null>();
 	const message = 'test';
 	let context: TextInputCommandContext;
 	const emptyBuffer: Buffer = Buffer.from([]);
@@ -34,7 +34,7 @@ describe('Talk Slash Command', () => {
 		} as unknown as TextInputCommandContext;
 		dectalkMock.mockResolvedValue(emptyBuffer);
 		speakerMock.mockReturnValue(null);
-		getStringMock.mockImplementation((name) => {
+		getStringMock.mockImplementation(name => {
 			if (name === 'message') return message;
 			if (name === 'speaker') return speakerMock();
 			return null;

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -59,6 +59,7 @@ describe('Talk Slash Command', () => {
 	test('Calls dectalk-tts module to generate wav buffer', async () => {
 		await expect(talk.execute(context)).resolves.toBeUndefined();
 		expect(dectalkMock).toHaveBeenCalledOnce();
+		expect(dectalkMock).toHaveBeenCalledWith(message);
 	});
 
 	test('Prepends the speaker name to the message if provided', async () => {

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -10,10 +10,10 @@ vi.mock('dectalk-tts', () => ({ default: dectalkMock }));
 vi.mock('../logger');
 
 // Import the code to test
-import { talk } from './talk.js';
+import { Speaker, talk } from './talk.js';
 
 describe('Talk Slash Command', () => {
-	const speakerMock = vi.fn<[], string | null>();
+	const speakerMock = vi.fn<[], Speaker | null>();
 	const message = 'test';
 	let context: TextInputCommandContext;
 	const emptyBuffer: Buffer = Buffer.from([]);
@@ -62,7 +62,7 @@ describe('Talk Slash Command', () => {
 	});
 
 	test('Prepends the speaker name to the message if provided', async () => {
-		const name = 'PAUL';
+		const name = Speaker.Paul;
 		speakerMock.mockReturnValueOnce(name);
 
 		await expect(talk.execute(context)).resolves.toBeUndefined();

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -3,14 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ChannelType } from 'discord.js';
 
 // Overwrite dectalk say method
-const mockSay = vi.hoisted(() => vi.fn());
-vi.mock('dectalk', async () => {
-	const dectalk = await vi.importActual<typeof import('dectalk')>('dectalk');
-	return {
-		...dectalk,
-		say: mockSay,
-	};
-});
+const dectalkMock = vi.hoisted(() => vi.fn());
+vi.mock('dectalk-tts', async () => ({ default: dectalkMock }));
 
 // Mock the logger so nothing is printed
 vi.mock('../logger');
@@ -19,39 +13,36 @@ vi.mock('../logger');
 import { talk } from './talk.js';
 
 describe('Talk Slash Command', () => {
+	const speakerMock = vi.fn();
 	const message = 'test';
 	let context: TextInputCommandContext;
 	const emptyBuffer: Buffer = Buffer.from([]);
-	const mockPrepare = vi.fn();
-	const mockReply = vi.fn();
-	const mockGetString = vi.fn();
-	const mockGetInteger = vi.fn();
+	const prepareForLongRunningTasksMock = vi.fn();
+	const replyMock = vi.fn();
+	const getStringMock = vi.fn();
 
 	beforeEach(() => {
 		context = {
 			options: {
-				getString: mockGetString,
-				getInteger: mockGetInteger,
+				getString: getStringMock,
 			},
 			channel: {
 				type: ChannelType.GuildText,
 			},
-			prepareForLongRunningTasks: mockPrepare,
-			reply: mockReply,
+			prepareForLongRunningTasks: prepareForLongRunningTasksMock,
+			reply: replyMock,
 		} as unknown as TextInputCommandContext;
-		mockSay.mockReturnValue(emptyBuffer);
-		mockGetString.mockReturnValue(message);
-		mockGetInteger.mockReturnValue(null);
+		dectalkMock.mockResolvedValue(emptyBuffer);
+		speakerMock.mockReturnValue(null);
+		getStringMock.mockImplementation((name) => {
+			if (name === 'message') return message;
+			if (name === 'speaker') return speakerMock();
+			return null;
+		});
 	});
 
 	afterEach(() => {
 		vi.resetAllMocks();
-	});
-
-	test('Fails if no options are provided', async () => {
-		mockGetInteger.mockReturnValueOnce(null);
-		mockGetString.mockReturnValueOnce(null);
-		await expect(talk.execute(context)).rejects.toThrow();
 	});
 
 	test('Fails if channel is undefined', async () => {
@@ -61,13 +52,21 @@ describe('Talk Slash Command', () => {
 
 	test('Prepares for long-running tasks and resolves interaction', async () => {
 		await expect(talk.execute(context)).resolves.toBeUndefined();
-		expect(mockPrepare).toHaveBeenCalledOnce();
-		expect(mockReply).toHaveBeenCalledOnce();
+		expect(prepareForLongRunningTasksMock).toHaveBeenCalledOnce();
+		expect(replyMock).toHaveBeenCalledOnce();
 	});
 
-	test('Calls dectalk module to generate wav buffer', async () => {
+	test('Calls dectalk-tts module to generate wav buffer', async () => {
 		await expect(talk.execute(context)).resolves.toBeUndefined();
-		expect(mockSay).toHaveBeenCalledOnce();
+		expect(dectalkMock).toHaveBeenCalledOnce();
+	});
+
+	test('Prepends the speaker name to the message if provided', async () => {
+		const name = 'PAUL';
+		speakerMock.mockReturnValueOnce(name);
+
+		await expect(talk.execute(context)).resolves.toBeUndefined();
+		expect(dectalkMock).toHaveBeenCalledWith(`[:name ${name}] ${message}`);
 	});
 
 	test('Replies with content of the message and the wav buffer in text channels', async () => {
@@ -76,7 +75,7 @@ describe('Talk Slash Command', () => {
 			channel: { type: ChannelType.GuildText },
 		} as unknown as TextInputCommandContext;
 		await expect(talk.execute(context)).resolves.toBeUndefined();
-		expect(mockReply).toHaveBeenCalledWith({
+		expect(replyMock).toHaveBeenCalledWith({
 			files: [
 				{
 					name: `${message}.wav`,

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -17,18 +17,30 @@ import { fileSync } from 'tmp';
 
 import { info } from '../logger.js';
 
-const SPEAKERS = ['PAUL', 'BETTY', 'HARRY', 'FRANK', 'DENNIS', 'KIT', 'URSULA', 'RITA', 'WENDY'];
+export enum Speaker {
+	Paul = 'PAUL',
+	Betty = 'BETTY',
+	Harry = 'HARRY',
+	Frank = 'FRANK',
+	Dennis = 'DENNIS',
+	Kit = 'KIT',
+	Ursula = 'URSULA',
+	Rita = 'RITA',
+	Wendy = 'WENDY',
+}
 
 const builder = new SlashCommandBuilder()
 	.setName('talk')
-	.setDescription('Uses Dectalk to speak the given message')
+	.setDescription('Uses Dectalk to speak the given message (via https://tts.cyzon.us/)')
 	.addStringOption(option =>
 		option.setRequired(true).setName('message').setDescription('The message to speak')
 	)
 	.addStringOption(option => {
 		option.setRequired(false).setName('speaker').setDescription('Whose voice to use');
-		SPEAKERS.forEach(name => {
-			option = option.addChoices({ name, value: name });
+		Object.keys(Speaker).forEach(name => {
+			const value = (Speaker as Record<string, string>)[name];
+			if (value === undefined) return;
+			option = option.addChoices({ name, value });
 		});
 		return option;
 	});
@@ -39,7 +51,7 @@ export const talk: GlobalCommand = {
 	async execute(context) {
 		const options = context.options;
 		const message = options.getString('message', true);
-		const speaker = options.getString('speaker', false) ?? undefined;
+		const speaker = options.getString('speaker', false) as Speaker|undefined ?? undefined;
 
 		await speak(context, message, speaker);
 	},
@@ -50,12 +62,12 @@ export const talk: GlobalCommand = {
  * by either slash commands or context commands
  * @param context The context of the interaction (either TextInputCommandContext or MessageContextCommandContext)
  * @param message The message to speak
- * @param speaker Which speaker to use (can be undefined)
+ * @param speaker Which speaker to use
  */
 export async function speak(
 	{ channel, client, prepareForLongRunningTasks, reply }: BaseCommandContext,
 	message: string,
-	speaker?: string
+	speaker?: Speaker
 ): Promise<void> {
 	// This also shouldn't happen, but better safe than sorry
 	if (!channel) {

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -17,9 +17,7 @@ import { fileSync } from 'tmp';
 
 import { info } from '../logger.js';
 
-const SPEAKERS = [
-	"PAUL", "BETTY", "HARRY", "FRANK", "DENNIS", "KIT", "URSULA", "RITA", "WENDY"
-];
+const SPEAKERS = ['PAUL', 'BETTY', 'HARRY', 'FRANK', 'DENNIS', 'KIT', 'URSULA', 'RITA', 'WENDY'];
 
 const builder = new SlashCommandBuilder()
 	.setName('talk')
@@ -57,7 +55,7 @@ export const talk: GlobalCommand = {
 export async function speak(
 	{ channel, client, prepareForLongRunningTasks, reply }: BaseCommandContext,
 	message: string,
-	speaker?: string,
+	speaker?: string
 ): Promise<void> {
 	// This also shouldn't happen, but better safe than sorry
 	if (!channel) {

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -11,11 +11,15 @@ import {
 	NoSubscriberBehavior,
 	entersState,
 } from '@discordjs/voice';
-import { say, Speaker } from 'dectalk';
+import dectalk from 'dectalk-tts';
 import { writeFileSync, createReadStream } from 'node:fs';
 import { fileSync } from 'tmp';
 
 import { info } from '../logger.js';
+
+const SPEAKERS = [
+	"PAUL", "BETTY", "HARRY", "FRANK", "DENNIS", "KIT", "URSULA", "RITA", "WENDY"
+];
 
 const builder = new SlashCommandBuilder()
 	.setName('talk')
@@ -23,16 +27,11 @@ const builder = new SlashCommandBuilder()
 	.addStringOption(option =>
 		option.setRequired(true).setName('message').setDescription('The message to speak')
 	)
-	.addIntegerOption(option => {
+	.addStringOption(option => {
 		option.setRequired(false).setName('speaker').setDescription('Whose voice to use');
-
-		const elements = Object.values(Speaker).filter(Number.isInteger) as Array<number>;
-		elements.forEach(value => {
-			const name = Speaker[value];
-			if (name === undefined) return;
-			option = option.addChoices({ name, value });
+		SPEAKERS.forEach(name => {
+			option = option.addChoices({ name, value: name });
 		});
-
 		return option;
 	});
 
@@ -42,42 +41,40 @@ export const talk: GlobalCommand = {
 	async execute(context) {
 		const options = context.options;
 		const message = options.getString('message', true);
-		const speakerNum = options.getInteger('speaker') ?? undefined;
+		const speaker = options.getString('speaker', false) ?? undefined;
 
-		await speak(message, speakerNum, context);
+		await speak(context, message, speaker);
 	},
 };
 
 /**
  * This method abstracts-out the functionality of the "talk" command, allowing it to be used
  * by either slash commands or context commands
- * @param message The message to speak
- * @param speakerNum Which speaker to use (can be undefined)
  * @param context The context of the interaction (either TextInputCommandContext or MessageContextCommandContext)
+ * @param message The message to speak
+ * @param speaker Which speaker to use (can be undefined)
  */
 export async function speak(
+	{ channel, client, prepareForLongRunningTasks, reply }: BaseCommandContext,
 	message: string,
-	speakerNum: Speaker | undefined,
-	{ channel, client, prepareForLongRunningTasks, reply }: BaseCommandContext
+	speaker?: string,
 ): Promise<void> {
 	// This also shouldn't happen, but better safe than sorry
 	if (!channel) {
 		throw new Error('No channel');
 	}
 
-	// This could happen if the user uses the context menu command on an empty message
-	if (!message || message === '') {
-		throw new Error('Message cannot be empty');
-	}
-
 	// Generating the audio can take a while, so make sure Discord doesn't think we died
 	await prepareForLongRunningTasks(false);
 
+	// If the speaker is defined, prepend the message with the speaker's name
+	if (speaker) {
+		message = `[:name ${speaker}] ` + message;
+	}
+
 	// Generate the audio and store it in a generic buffer
 	log('generating audio');
-	const wavData: Buffer = await say(message, {
-		Speaker: speakerNum,
-	});
+	const wavData = await dectalk(message);
 
 	// If the command was given in a voice chat, speak it
 	if (channel.type === ChannelType.GuildVoice) {

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -51,7 +51,7 @@ export const talk: GlobalCommand = {
 	async execute(context) {
 		const options = context.options;
 		const message = options.getString('message', true);
-		const speaker = options.getString('speaker', false) as Speaker|undefined ?? undefined;
+		const speaker = (options.getString('speaker', false) as Speaker | undefined) ?? undefined;
 
 		await speak(context, message, speaker);
 	},

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -51,7 +51,7 @@ export const talk: GlobalCommand = {
 	async execute(context) {
 		const options = context.options;
 		const message = options.getString('message', true);
-		const speaker = (options.getString('speaker', false) as Speaker | undefined) ?? undefined;
+		const speaker = (options.getString('speaker', false) as Speaker | null) ?? undefined;
 
 		await speak(context, message, speaker);
 	},
@@ -69,9 +69,14 @@ export async function speak(
 	message: string,
 	speaker?: Speaker
 ): Promise<void> {
-	// This also shouldn't happen, but better safe than sorry
+	// This shouldn't happen, but better safe than sorry
 	if (!channel) {
 		throw new Error('No channel');
+	}
+
+	// This could happen if the user uses the context menu command on an empty message
+	if (!message || message.trim() === '') {
+		throw new Error('Message cannot be empty');
 	}
 
 	// Generating the audio can take a while, so make sure Discord doesn't think we died


### PR DESCRIPTION
The old `dectalk` package was a little sketchy - it created a child process to run an unprotected executable on the local machine, and it required special OS dependencies on Linux. And it didn't work on Mac.

This new package simply calls a web API, so the dectalk executable does not need to be run locally anymore. This should be much safer.