### PR TITLE
Prefer 0BSD over Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,12 @@
-This is free and unencumbered software released into the public domain.
+BSD Zero Clause License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [CONTRIBUTING.md](/CONTRIBUTING.md) for ways to contribute.
 
 ## License
 
-This project's source is licensed under the [Unlicense](LICENSE) license. All contributions to this project's source are understood to be given to the public domain.
+This project's source is licensed under the [BSD Zero Clause License](LICENSE). All contributions to this project's source may be used, copied, modified, and/or distributed for any purpose.
 
 ## Table of contents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "csbot",
 			"version": "0.12.1",
-			"license": "Unlicense",
+			"license": "0BSD",
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
 				"@prisma/client": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"type": "git",
 		"url": "git+https://github.com/BYU-CS-Discord/CSBot.git"
 	},
-	"license": "Unlicense",
+	"license": "0BSD",
 	"author": "BYU CS",
 	"type": "module",
 	"main": "./dist/main.js",


### PR DESCRIPTION
[Apparently](https://opensource.stackexchange.com/a/12073), the public domain dedication in Unlicense makes our code unusable in jurisdictions where public domain is not a recognized legal concept.

Per [our original discussion](https://discord.com/channels/1024162246491914240/1024162247041359895/1024179046306811904) on this, we want a license that gives "zero conditions, full permissions". In the spirit of that goal, I recommend we use 0BSD instead of Unlicense.