### PR TITLE
Resolve all npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4823,11 +4823,26 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/ip": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
-			"dev": true
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ip-address/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.2",
@@ -5234,6 +5249,13 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsesc": {
 			"version": "3.0.2",
@@ -6092,13 +6114,13 @@
 			}
 		},
 		"node_modules/pac-resolver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-			"integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"degenerator": "^5.0.0",
-				"ip": "^1.1.8",
 				"netmask": "^2.0.2"
 			},
 			"engines": {
@@ -7270,16 +7292,17 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -7308,12 +7331,6 @@
 			"engines": {
 				"node": ">= 14"
 			}
-		},
-		"node_modules/socks/node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-			"dev": true
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",


### PR DESCRIPTION
These fixes have to be made manually because Dependabot can't do them.

![image](https://github.com/BYU-CS-Discord/CSBot/assets/28303477/326dbc65-368c-4a1b-935a-653c4fc3a8ff)

Changelog is already up-to-date, because we haven't made another release since the last time I did this.

### Fixed

- All npm vulnerabilities by running `npm audit fix`
  - https://github.com/BYU-CS-Discord/CSBot/security/dependabot/33
  - https://github.com/BYU-CS-Discord/CSBot/security/dependabot/28
  - https://github.com/BYU-CS-Discord/CSBot/security/dependabot/27
  