### PR TITLE
docs: Use more specific server invite

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may
-be reported by contacting the project team [via Discord](https://discord.gg/bnV89Cz).
+be reported by contacting the project team [via Discord](https://discord.gg/CMhcP99p93).
 All complaints will be reviewed and investigated and will result in a
 response that is deemed necessary and appropriate to the circumstances.
 The project team is obligated to maintain confidentiality with regard to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ the action you have taken to solve it.
 
 The aim of this project is:
 
-- To provide useful and fun functions for the participants of [our Discord server](https://discord.gg/bnV89Cz).
+- To provide useful and fun functions for the participants of [our Discord server](https://discord.gg/CMhcP99p93).
 - To be usable by someone who is familiar with Discord and Discord bots.
 - To foster a culture of respect and gratitude in the open-source space.
 


### PR DESCRIPTION
Link the bot-specific server invite, instead of the one for the main server.