### PR TITLE
Upgrade to vitest v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@types/node": "20.8.8",
 				"@types/source-map-support": "0.5.6",
 				"@types/tmp": "0.2.3",
-				"@vitest/coverage-istanbul": "1.2.1",
+				"@vitest/coverage-istanbul": "2.0.2",
 				"eslint": "8.56.0",
 				"eslint-plugin-deprecation": "2.0.0",
 				"eslint-plugin-file-progress": "1.3.0",
@@ -44,7 +44,7 @@
 				"tsx": "4.7.0",
 				"typescript": "5.3.3",
 				"typescript-eslint": "7.16.0",
-				"vitest": "1.2.1",
+				"vitest": "2.0.2",
 				"vitest-mock-extended": "1.3.1"
 			},
 			"engines": {
@@ -61,127 +61,60 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.8.tgz",
+			"integrity": "sha512-c4IM7OTg6k1Q+AJ153e2mc2QVTezTwnb4VzquwcyiEzGnW0Kedv4do/TrkU98qPeC5LNiMt/QXwIjzYXLBpyZg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
-			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.8.tgz",
+			"integrity": "sha512-6AWcmZC/MZCO0yKys4uhg5NlxL0ESF3K6IAaoQ+xSXvPyPyxNWRafP+GDbI88Oh68O7QkJgmEtedWPM9U0pZNg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.7",
-				"@babel/parser": "^7.23.6",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.8",
+				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/helper-module-transforms": "^7.24.8",
+				"@babel/helpers": "^7.24.8",
+				"@babel/parser": "^7.24.8",
+				"@babel/template": "^7.24.7",
+				"@babel/traverse": "^7.24.8",
+				"@babel/types": "^7.24.8",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -201,19 +134,21 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.8.tgz",
+			"integrity": "sha512-47DG+6F5SzOi0uEvK4wMShmn5yY0mVjVJoWTphdY2B4Rx9wHgjK7Yhtr0ru6nE+sn0v38mzrWOlah0p/YlHHOQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.23.6",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
+				"@babel/types": "^7.24.8",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -225,6 +160,7 @@
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -233,14 +169,15 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+			"integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.23.5",
-				"@babel/helper-validator-option": "^7.23.5",
-				"browserslist": "^4.22.2",
+				"@babel/compat-data": "^7.24.8",
+				"@babel/helper-validator-option": "^7.24.8",
+				"browserslist": "^4.23.1",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -253,67 +190,77 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.24.7"
+			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.8.tgz",
+			"integrity": "sha512-m4vWKVqvkVAWLXfHCCfff2luJj86U+J0/x+0N3ArG/tP0Fq7zky2dYwMbtPmkc/oulkkbjdL3uWzuoBwQ8R00Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-simple-access": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/helper-validator-identifier": "^7.22.20"
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -323,79 +270,87 @@
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
-			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
+			"integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6"
+				"@babel/template": "^7.24.7",
+				"@babel/types": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -406,6 +361,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -418,6 +374,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -432,6 +389,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -440,13 +398,15 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -456,6 +416,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -465,6 +426,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -473,10 +435,11 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+			"integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -485,33 +448,35 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+			"integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.24.8",
+				"@babel/helper-environment-visitor": "^7.24.7",
+				"@babel/helper-function-name": "^7.24.7",
+				"@babel/helper-hoist-variables": "^7.24.7",
+				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/parser": "^7.24.8",
+				"@babel/types": "^7.24.8",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -524,18 +489,20 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.8.tgz",
+			"integrity": "sha512-SkSBEHwwJRU52QEVZBmMBnE5Ux2/6WU1grdYyOhpbCNxbmJrDuDCphBzKZSO3taf0zztp+qkWlymE5tVL5l0TA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.23.4",
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-string-parser": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1184,36 +1151,73 @@
 			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
 			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-			"dev": true,
-			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1229,10 +1233,11 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1244,10 +1249,11 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.22",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
-			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1349,6 +1355,17 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -1573,6 +1590,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -1586,6 +1604,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -1599,6 +1618,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1612,6 +1632,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1625,6 +1646,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1638,6 +1660,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1651,6 +1674,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1664,6 +1688,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1677,6 +1702,7 @@
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1690,6 +1716,7 @@
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1703,6 +1730,7 @@
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1716,6 +1744,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1729,6 +1758,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1742,6 +1772,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1755,6 +1786,7 @@
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1768,6 +1800,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1802,12 +1835,6 @@
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
 			}
-		},
-		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-			"dev": true
 		},
 		"node_modules/@stylistic/eslint-plugin": {
 			"version": "1.5.4",
@@ -1904,7 +1931,8 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -2529,119 +2557,112 @@
 			"dev": true
 		},
 		"node_modules/@vitest/coverage-istanbul": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-1.2.1.tgz",
-			"integrity": "sha512-j8M4R3XbQ7cmLqJd7mfxCpEc0bQ7S6o5VIEt7c0Auri2lT1hkd89Sa/mOYDnuGasTNawamW+0d9vDRK/5uhVXw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.0.2.tgz",
+			"integrity": "sha512-9TZC/4CT9j7GZYwh1fYtxNtRoSi7T4evF5M/rxOOAvgejJFxM/ysXSvdyV/HXWkEbH/Be8uKnd+v/TyYyrglGA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.4",
+				"@istanbuljs/schema": "^0.1.3",
+				"debug": "^4.3.5",
 				"istanbul-lib-coverage": "^3.2.2",
-				"istanbul-lib-instrument": "^6.0.1",
+				"istanbul-lib-instrument": "^6.0.3",
 				"istanbul-lib-report": "^3.0.1",
-				"istanbul-lib-source-maps": "^4.0.1",
-				"istanbul-reports": "^3.1.6",
-				"magicast": "^0.3.3",
-				"picocolors": "^1.0.0",
-				"test-exclude": "^6.0.0"
+				"istanbul-lib-source-maps": "^5.0.6",
+				"istanbul-reports": "^3.1.7",
+				"magicast": "^0.3.4",
+				"test-exclude": "^7.0.1",
+				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": "^1.0.0"
+				"vitest": "2.0.2"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.1.tgz",
-			"integrity": "sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.2.tgz",
+			"integrity": "sha512-nKAvxBYqcDugYZ4nJvnm5OR8eDJdgWjk4XM9owQKUjzW70q0icGV2HVnQOyYsp906xJaBDUXw0+9EHw2T8e0mQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "1.2.1",
-				"@vitest/utils": "1.2.1",
-				"chai": "^4.3.10"
+				"@vitest/spy": "2.0.2",
+				"@vitest/utils": "2.0.2",
+				"chai": "^5.1.1",
+				"tinyrainbow": "^1.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.2.tgz",
+			"integrity": "sha512-SBCyOXfGVvddRd9r2PwoVR0fonQjh9BMIcBMlSzbcNwFfGr6ZhOhvBzurjvi2F4ryut2HcqiFhNeDVGwru8tLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.1.tgz",
-			"integrity": "sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.2.tgz",
+			"integrity": "sha512-OCh437Vi8Wdbif1e0OvQcbfM3sW4s2lpmOjAE7qfLrpzJX2M7J1IQlNvEcb/fu6kaIB9n9n35wS0G2Q3en5kHg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "1.2.1",
-				"p-limit": "^5.0.0",
-				"pathe": "^1.1.1"
+				"@vitest/utils": "2.0.2",
+				"pathe": "^1.1.2"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/runner/node_modules/p-limit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-			"integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-			"dev": true,
-			"dependencies": {
-				"yocto-queue": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@vitest/runner/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@vitest/snapshot": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.1.tgz",
-			"integrity": "sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.2.tgz",
+			"integrity": "sha512-Yc2ewhhZhx+0f9cSUdfzPRcsM6PhIb+S43wxE7OG0kTxqgqzo8tHkXFuFlndXeDMp09G3sY/X5OAo/RfYydf1g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"magic-string": "^0.30.5",
-				"pathe": "^1.1.1",
-				"pretty-format": "^29.7.0"
+				"@vitest/pretty-format": "2.0.2",
+				"magic-string": "^0.30.10",
+				"pathe": "^1.1.2"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.1.tgz",
-			"integrity": "sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.2.tgz",
+			"integrity": "sha512-MgwJ4AZtCgqyp2d7WcQVE8aNG5vQ9zu9qMPYQHjsld/QVsrvg78beNrXdO4HYkP0lDahCO3P4F27aagIag+SGQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"tinyspy": "^2.2.0"
+				"tinyspy": "^3.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.2.tgz",
+			"integrity": "sha512-pxCY1v7kmOCWYWjzc0zfjGTA3Wmn8PKnlPvSrsA643P1NHl1fOyXj2Q9SaNlrlFE+ivCsxM80Ov3AR82RmHCWQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"diff-sequences": "^29.6.3",
+				"@vitest/pretty-format": "2.0.2",
 				"estree-walker": "^3.0.3",
-				"loupe": "^2.3.7",
-				"pretty-format": "^29.7.0"
+				"loupe": "^3.1.1",
+				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -2672,15 +2693,6 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/acorn-walk": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -2895,12 +2907,13 @@
 			}
 		},
 		"node_modules/assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			}
 		},
 		"node_modules/ast-types": {
@@ -3066,9 +3079,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+			"version": "4.23.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+			"integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3084,11 +3097,12 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001565",
-				"electron-to-chromium": "^1.4.601",
+				"caniuse-lite": "^1.0.30001640",
+				"electron-to-chromium": "^1.4.820",
 				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.13"
+				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3143,6 +3157,7 @@
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3171,9 +3186,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001579",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-			"integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+			"version": "1.0.30001641",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
+			"integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3188,7 +3203,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
@@ -3196,21 +3212,20 @@
 			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
 		},
 		"node_modules/chai": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+			"integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.3",
-				"deep-eql": "^4.1.3",
-				"get-func-name": "^2.0.2",
-				"loupe": "^2.3.6",
-				"pathval": "^1.1.1",
-				"type-detect": "^4.0.8"
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=12"
 			}
 		},
 		"node_modules/chalk": {
@@ -3236,15 +3251,13 @@
 			"dev": true
 		},
 		"node_modules/check-error": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
 			"dev": true,
-			"dependencies": {
-				"get-func-name": "^2.0.2"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": "*"
+				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
@@ -3452,7 +3465,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.35.0",
@@ -3509,9 +3523,10 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -3533,13 +3548,11 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
 			"dev": true,
-			"dependencies": {
-				"type-detect": "^4.0.0"
-			},
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3616,15 +3629,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3685,11 +3689,19 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.640",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.640.tgz",
-			"integrity": "sha512-z/6oZ/Muqk4BaE7P69bXhUhpJbUM9ZJeka43ZwxsDshKtePns4mhBlh8bU5+yrnOnz3fhG82XLzGUXazOmsWnA==",
-			"dev": true
+			"version": "1.4.827",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
+			"integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/emitter-listener": {
 			"version": "1.1.2",
@@ -3699,6 +3711,13 @@
 			"dependencies": {
 				"shimmer": "^1.2.0"
 			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/enquirer": {
 			"version": "2.3.6",
@@ -3861,10 +3880,11 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -4321,6 +4341,7 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -4603,6 +4624,36 @@
 				"is-callable": "^1.1.3"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+			"integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -4691,6 +4742,7 @@
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -4716,6 +4768,7 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
 			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -5018,7 +5071,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.0",
@@ -5338,6 +5392,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5530,19 +5594,21 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
 			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/istanbul-lib-instrument": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-			"integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
 				"istanbul-lib-coverage": "^3.2.0",
 				"semver": "^7.5.4"
 			},
@@ -5555,6 +5621,7 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
 			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^4.0.0",
@@ -5565,30 +5632,48 @@
 			}
 		},
 		"node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
+				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/js-git": {
@@ -5607,7 +5692,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -5676,18 +5762,13 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-			"dev": true
 		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
@@ -5760,22 +5841,6 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
-		"node_modules/local-pkg": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
-			"integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
-			"dev": true,
-			"dependencies": {
-				"mlly": "^1.4.2",
-				"pkg-types": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5833,10 +5898,11 @@
 			}
 		},
 		"node_modules/loupe": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+			"integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"get-func-name": "^2.0.1"
 			}
@@ -5846,31 +5912,31 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.5",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"version": "0.30.10",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.3.tgz",
-			"integrity": "sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.4.tgz",
+			"integrity": "sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
-				"source-map-js": "^1.0.2"
+				"@babel/parser": "^7.24.4",
+				"@babel/types": "^7.24.0",
+				"source-map-js": "^1.2.0"
 			}
 		},
 		"node_modules/make-dir": {
@@ -5878,6 +5944,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
 			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.3"
 			},
@@ -5979,6 +6046,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/mkdirp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5989,18 +6066,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/mlly": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
-			"integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.11.3",
-				"pathe": "^1.1.2",
-				"pkg-types": "^1.0.3",
-				"ufo": "^1.3.2"
 			}
 		},
 		"node_modules/module-details-from-path": {
@@ -6031,6 +6096,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -6498,6 +6564,13 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/pako": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -6589,6 +6662,30 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6602,15 +6699,17 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
 			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pathval": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+			"integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": "*"
+				"node": ">= 14.16"
 			}
 		},
 		"node_modules/peek-readable": {
@@ -6653,17 +6752,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/pkg-types": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
-			"integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
-			"dev": true,
-			"dependencies": {
-				"jsonc-parser": "^3.2.0",
-				"mlly": "^1.2.0",
-				"pathe": "^1.1.0"
 			}
 		},
 		"node_modules/pluralize": {
@@ -6838,6 +6926,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.1",
@@ -6897,32 +6986,6 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=2 || >=3"
-			}
-		},
-		"node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/prism-media": {
@@ -7077,12 +7140,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/react-is": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-			"dev": true
 		},
 		"node_modules/read": {
 			"version": "1.0.7",
@@ -7376,6 +7433,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
 			"integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.5"
 			},
@@ -7787,6 +7845,76 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/string.prototype.trim": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
@@ -7844,6 +7972,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7887,18 +8029,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strip-literal": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
-			"integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/strtok3": {
@@ -7993,39 +8123,55 @@
 			}
 		},
 		"node_modules/test-exclude": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+			"integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@istanbuljs/schema": "^0.1.2",
-				"glob": "^7.1.4",
-				"minimatch": "^3.0.4"
+				"glob": "^10.4.1",
+				"minimatch": "^9.0.4"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/text-table": {
@@ -8035,25 +8181,38 @@
 			"dev": true
 		},
 		"node_modules/tinybench": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
-			"integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
-			"dev": true
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+			"integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinypool": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.2.tgz",
-			"integrity": "sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
+			"integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+			"integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
-			"integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
+			"integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -8074,6 +8233,7 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -8248,15 +8408,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/type-fest": {
@@ -8512,12 +8663,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/ufo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
-			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
-			"dev": true
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8565,9 +8710,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8583,9 +8728,10 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -8636,6 +8782,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
 			"integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.39",
@@ -8687,15 +8834,16 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.1.tgz",
-			"integrity": "sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.2.tgz",
+			"integrity": "sha512-w4vkSz1Wo+NIQg8pjlEn0jQbcM/0D+xVaYjhw3cvarTanLLBh54oNiRbsT8PNK5GfuST0IlVXjsNRoNlqvY/fw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.14",
-				"debug": "^4.3.4",
-				"pathe": "^1.1.1",
-				"picocolors": "^1.0.0",
+				"debug": "^4.3.5",
+				"pathe": "^1.1.2",
+				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0"
 			},
 			"bin": {
@@ -8716,6 +8864,7 @@
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"aix"
@@ -8732,6 +8881,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -8748,6 +8898,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -8764,6 +8915,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -8780,6 +8932,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -8796,6 +8949,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -8812,6 +8966,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -8828,6 +8983,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -8844,6 +9000,7 @@
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8860,6 +9017,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8876,6 +9034,7 @@
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8892,6 +9051,7 @@
 				"loong64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8908,6 +9068,7 @@
 				"mips64el"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8924,6 +9085,7 @@
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8940,6 +9102,7 @@
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8956,6 +9119,7 @@
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8972,6 +9136,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -8988,6 +9153,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -9004,6 +9170,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -9020,6 +9187,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"sunos"
@@ -9036,6 +9204,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -9052,6 +9221,7 @@
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -9068,6 +9238,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -9082,6 +9253,7 @@
 			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -9115,31 +9287,30 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.1.tgz",
-			"integrity": "sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.2.tgz",
+			"integrity": "sha512-WlpZ9neRIjNBIOQwBYfBSr0+of5ZCbxT2TVGKW4Lv0c8+srCFIiRdsP7U009t8mMn821HQ4XKgkx5dVWpyoyLw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "1.2.1",
-				"@vitest/runner": "1.2.1",
-				"@vitest/snapshot": "1.2.1",
-				"@vitest/spy": "1.2.1",
-				"@vitest/utils": "1.2.1",
-				"acorn-walk": "^8.3.2",
-				"cac": "^6.7.14",
-				"chai": "^4.3.10",
-				"debug": "^4.3.4",
+				"@ampproject/remapping": "^2.3.0",
+				"@vitest/expect": "2.0.2",
+				"@vitest/pretty-format": "^2.0.2",
+				"@vitest/runner": "2.0.2",
+				"@vitest/snapshot": "2.0.2",
+				"@vitest/spy": "2.0.2",
+				"@vitest/utils": "2.0.2",
+				"chai": "^5.1.1",
+				"debug": "^4.3.5",
 				"execa": "^8.0.1",
-				"local-pkg": "^0.5.0",
-				"magic-string": "^0.30.5",
-				"pathe": "^1.1.1",
-				"picocolors": "^1.0.0",
-				"std-env": "^3.5.0",
-				"strip-literal": "^1.3.0",
-				"tinybench": "^2.5.1",
-				"tinypool": "^0.8.1",
+				"magic-string": "^0.30.10",
+				"pathe": "^1.1.2",
+				"std-env": "^3.7.0",
+				"tinybench": "^2.8.0",
+				"tinypool": "^1.0.0",
+				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "1.2.1",
+				"vite-node": "2.0.2",
 				"why-is-node-running": "^2.2.2"
 			},
 			"bin": {
@@ -9154,8 +9325,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "^1.0.0",
-				"@vitest/ui": "^1.0.0",
+				"@vitest/browser": "2.0.2",
+				"@vitest/ui": "2.0.2",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},
@@ -9292,6 +9463,107 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9321,7 +9593,8 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/yamljs": {
 			"version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9356,6 +9356,7 @@
 			"resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-1.3.1.tgz",
 			"integrity": "sha512-OpghYjh4BDuQ/Mzs3lFMQ1QRk9D8/2O9T47MLUA5eLn7K4RWIy+MfIivYOWEyxjTENjsBnzgMihDjyNalN/K0Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ts-essentials": "^9.3.2"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "0BSD",
 			"dependencies": {
 				"@discordjs/voice": "0.15.0",
-				"@prisma/client": "4.3.1",
+				"@prisma/client": "4.16.2",
 				"dectalk-tts": "1.0.1",
 				"discord.js": "14.9.0",
 				"dotenv": "16.0.3",
@@ -39,7 +39,7 @@
 				"pm2": "5.3.0",
 				"prettier": "3.2.4",
 				"prettier-plugin-prisma": "5.0.0",
-				"prisma": "4.3.1",
+				"prisma": "4.16.2",
 				"semver": "7.5.4",
 				"tsx": "4.7.0",
 				"typescript": "5.3.3",
@@ -1545,12 +1545,13 @@
 			}
 		},
 		"node_modules/@prisma/client": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.3.1.tgz",
-			"integrity": "sha512-FA0/d1VMJNWqzU7WVWTNWJ+lGOLR9JUBnF73GdIPAEVo/6dWk4gHx0EmgeU+SMv4MZoxgOeTBJF2azhg7x0hMw==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+			"integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
 			"hasInstallScript": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/engines-version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b"
+				"@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 			},
 			"engines": {
 				"node": ">=14.17"
@@ -1565,16 +1566,18 @@
 			}
 		},
 		"node_modules/@prisma/engines": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.3.1.tgz",
-			"integrity": "sha512-4JF/uMaEDAPdcdZNOrnzE3BvrbGpjgV0FcPT3EVoi6I86fWkloqqxBt+KcK/+fIRR0Pxj66uGR9wVH8U1Y13JA==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+			"integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
 			"devOptional": true,
-			"hasInstallScript": true
+			"hasInstallScript": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.3.0-32.c875e43600dfe042452e0b868f7a48b817b9640b.tgz",
-			"integrity": "sha512-8yWpXkQRmiSfsi2Wb/ZS5D3RFbeu/btL9Pm/gdF4phB0Lo5KGsDFMxFMgaD64mwED2nHc8ZaEJg/+4Jymb9Znw=="
+			"version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+			"integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/prisma-schema-wasm": {
 			"version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
@@ -7014,13 +7017,14 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.3.1.tgz",
-			"integrity": "sha512-90xo06wtqil76Xsi3mNpc4Js3SdDRR5g4qb9h+4VWY4Y8iImJY6xc3PX+C9xxTSt1lr0Q89A0MLkJjd8ax6KiQ==",
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+			"integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
 			"devOptional": true,
 			"hasInstallScript": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/engines": "4.3.1"
+				"@prisma/engines": "4.16.2"
 			},
 			"bin": {
 				"prisma": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"@types/node": "20.8.8",
 		"@types/source-map-support": "0.5.6",
 		"@types/tmp": "0.2.3",
-		"@vitest/coverage-istanbul": "1.2.1",
+		"@vitest/coverage-istanbul": "2.0.2",
 		"eslint": "8.56.0",
 		"eslint-plugin-deprecation": "2.0.0",
 		"eslint-plugin-file-progress": "1.3.0",
@@ -81,7 +81,7 @@
 		"tsx": "4.7.0",
 		"typescript": "5.3.3",
 		"typescript-eslint": "7.16.0",
-		"vitest": "1.2.1",
+		"vitest": "2.0.2",
 		"vitest-mock-extended": "1.3.1"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	},
 	"dependencies": {
 		"@discordjs/voice": "0.15.0",
-		"@prisma/client": "4.3.1",
+		"@prisma/client": "4.16.2",
 		"dectalk-tts": "1.0.1",
 		"discord.js": "14.9.0",
 		"dotenv": "16.0.3",
@@ -76,7 +76,7 @@
 		"pm2": "5.3.0",
 		"prettier": "3.2.4",
 		"prettier-plugin-prisma": "5.0.0",
-		"prisma": "4.3.1",
+		"prisma": "4.16.2",
 		"semver": "7.5.4",
 		"tsx": "4.7.0",
 		"typescript": "5.3.3",

--- a/src/__mocks__/logger.ts
+++ b/src/__mocks__/logger.ts
@@ -1,25 +1,27 @@
 import { vi } from 'vitest';
 
+import type * as logger from '../logger.js';
+
 /**
  * The mock function serving as the `debug` method of the logger.
  * @public
  */
-export const debug = vi.fn();
+export const debug = vi.fn<typeof logger.debug>();
 
 /**
  * The mock function serving as the `info` method of the logger.
  * @public
  */
-export const info = vi.fn();
+export const info = vi.fn<typeof logger.info>();
 
 /**
  * The mock function serving as the `warn` method of the logger.
  * @public
  */
-export const warn = vi.fn();
+export const warn = vi.fn<typeof logger.warn>();
 
 /**
  * The mock function serving as the `error` method of the logger.
  * @public
  */
-export const error = vi.fn();
+export const error = vi.fn<typeof logger.error>();

--- a/src/buttons/hangmanLessButton.test.ts
+++ b/src/buttons/hangmanLessButton.test.ts
@@ -1,11 +1,9 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { MessageReplyOptions } from 'discord.js';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { hangmanLessButton } from './hangmanLessButton.js';
 
 describe('hangmanLessButton', () => {
-	const mockUpdate = vi.fn<[MessageReplyOptions]>();
+	const mockUpdate = vi.fn<ButtonContext['interaction']['update']>();
 	const message = {
 		embeds: [
 			{
@@ -31,8 +29,11 @@ describe('hangmanLessButton', () => {
 
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const response = mockUpdate.mock.calls.at(0)?.at(0);
-		expect(response?.embeds?.length).toEqual(1);
-		expect(response?.embeds?.at(0)).toBeTypeOf('object');
-		expect(response?.components?.length).toEqual(5);
+		if (!response || typeof response === 'string' || !('embeds' in response)) {
+			assert.fail('Did not update interaction with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		expect(response.embeds.at(0)).toBeTypeOf('object');
+		expect(response.components?.length).toEqual(5);
 	});
 });

--- a/src/buttons/hangmanLetterButton.test.ts
+++ b/src/buttons/hangmanLetterButton.test.ts
@@ -4,7 +4,7 @@ import { letterButtons } from '../evilHangman/hangmanLetterButtons.js';
 import { UserMessageError } from '../helpers/UserMessageError.js';
 
 describe('hangmanMoreButton', () => {
-	const mockUpdate = vi.fn();
+	const mockUpdate = vi.fn<ButtonContext['interaction']['update']>();
 	const beforeInfo = 'Remaining Guesses: 3\nWord: ---\nLetters Guessed: a';
 	const message = {
 		embeds: [

--- a/src/buttons/hangmanMoreButton.test.ts
+++ b/src/buttons/hangmanMoreButton.test.ts
@@ -1,11 +1,9 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { MessageReplyOptions } from 'discord.js';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { hangmanMoreButton } from './hangmanMoreButton.js';
 
 describe('hangmanMoreButton', () => {
-	const mockUpdate = vi.fn<[MessageReplyOptions]>();
+	const mockUpdate = vi.fn<ButtonContext['interaction']['update']>();
 	const message = {
 		embeds: [
 			{
@@ -31,8 +29,11 @@ describe('hangmanMoreButton', () => {
 
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const response = mockUpdate.mock.calls.at(0)?.at(0);
-		expect(response?.embeds?.length).toEqual(1);
-		expect(response?.embeds?.at(0)).toBeTypeOf('object');
-		expect(response?.components?.length).toEqual(1);
+		if (!response || typeof response === 'string' || !('embeds' in response)) {
+			assert.fail('Did not update interaction with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		expect(response.embeds.at(0)).toBeTypeOf('object');
+		expect(response.components?.length).toEqual(1);
 	});
 });

--- a/src/commandContext/followUp.test.ts
+++ b/src/commandContext/followUp.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { RepliableInteraction } from 'discord.js';
+import type { Message, RepliableInteraction } from 'discord.js';
 
 vi.mock('../helpers/actions/messages/replyToMessage.js');
 import { sendMessageInChannel } from '../helpers/actions/messages/replyToMessage.js';
@@ -14,8 +14,8 @@ import { error as mockLoggerError } from '../logger.js';
 import { followUpFactory as factory } from './followUp.js';
 
 describe('follow-up message', () => {
-	const testMessage = { id: 'test-message' };
-	const mockInteractionFollowUp = vi.fn();
+	const testMessage = { id: 'test-message' } as Message;
+	const mockInteractionFollowUp = vi.fn<RepliableInteraction['followUp']>();
 
 	beforeEach(() => {
 		mockSendMessageInChannel.mockResolvedValue(testMessage);

--- a/src/commandContext/prepareForLongRunningTasks.test.ts
+++ b/src/commandContext/prepareForLongRunningTasks.test.ts
@@ -9,7 +9,7 @@ import { error as mockLoggerError } from '../logger.js';
 import { prepareForLongRunningTasksFactory as factory } from './prepareForLongRunningTasks.js';
 
 describe('prepareForLongRunningTasks', () => {
-	const mockInteractionDeferReply = vi.fn();
+	const mockInteractionDeferReply = vi.fn<RepliableInteraction['deferReply']>();
 
 	const interaction = {
 		deferReply: mockInteractionDeferReply,

--- a/src/commandContext/reply.test.ts
+++ b/src/commandContext/reply.test.ts
@@ -9,7 +9,7 @@ import { error as mockLoggerError } from '../logger.js';
 import { replyFactory as factory } from './reply.js';
 
 describe('public reply', () => {
-	const mockInteractionReply = vi.fn();
+	const mockInteractionReply = vi.fn<RepliableInteraction['reply']>();
 
 	const interaction = {
 		user: { id: 'user-id-1234' },

--- a/src/commandContext/replyPrivately.test.ts
+++ b/src/commandContext/replyPrivately.test.ts
@@ -15,9 +15,9 @@ import { replyPrivatelyFactory as factory } from './replyPrivately.js';
 
 describe('ephemeral and DM replies', () => {
 	mockSendDM.mockResolvedValue(true);
-	const mockInteractionReply = vi.fn();
-	const mockInteractionEditReply = vi.fn();
-	const mockInteractionFollowUp = vi.fn();
+	const mockInteractionReply = vi.fn<RepliableInteraction['reply']>();
+	const mockInteractionEditReply = vi.fn<RepliableInteraction['editReply']>();
+	const mockInteractionFollowUp = vi.fn<RepliableInteraction['followUp']>();
 
 	let interaction: RepliableInteraction;
 	let replyPrivately: CommandContext['replyPrivately'];

--- a/src/commandContext/sendTyping.test.ts
+++ b/src/commandContext/sendTyping.test.ts
@@ -10,12 +10,12 @@ vi.mock('../logger.js');
 import { sendTypingFactory as factory } from './sendTyping.js';
 
 describe('typing indicator', () => {
-	let mockSendTyping: Mock<[], void>;
+	let mockSendTyping: Mock<NonNullable<RepliableInteraction['channel']>['sendTyping']>;
 	let interaction: RepliableInteraction;
 	let sendTyping: () => void;
 
 	beforeEach(() => {
-		mockSendTyping = vi.fn<[], undefined>();
+		mockSendTyping = vi.fn<NonNullable<RepliableInteraction['channel']>['sendTyping']>();
 		interaction = {
 			channel: {
 				sendTyping: mockSendTyping,

--- a/src/commands/contextMenu/altText.test.ts
+++ b/src/commands/contextMenu/altText.test.ts
@@ -6,7 +6,7 @@ import { Collection } from 'discord.js';
 import { altText } from './altText.js';
 
 describe('Get Alt Text', () => {
-	const mockReplyPrivately = vi.fn();
+	const mockReplyPrivately = vi.fn<MessageContextMenuCommandContext['replyPrivately']>();
 	let context: MessageContextMenuCommandContext;
 	let mockAttachments: Collection<string, Attachment>;
 

--- a/src/commands/contextMenu/fxtwitter.test.ts
+++ b/src/commands/contextMenu/fxtwitter.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { fxtwitter } from './fxtwitter.js';
 
 describe('Fix Twitter Links', () => {
-	const mockReplyPrivately = vi.fn();
+	const mockReplyPrivately = vi.fn<MessageContextMenuCommandContext['replyPrivately']>();
 	let context: MessageContextMenuCommandContext;
 
 	beforeEach(() => {

--- a/src/commands/contextMenu/talk.test.ts
+++ b/src/commands/contextMenu/talk.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { speak } from '../talk.js';
+
 // Mock the talkMessage functionality
-const speakMock = vi.hoisted(() => vi.fn());
+const speakMock = vi.hoisted(() => vi.fn<typeof speak>());
 vi.mock('../talk.js', () => ({
 	speak: speakMock,
 }));

--- a/src/commands/emoji.test.ts
+++ b/src/commands/emoji.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { GuildEmoji, ImageURLOptions } from 'discord.js';
+import type { GuildEmoji } from 'discord.js';
 import { EmbedBuilder } from 'discord.js';
 
 import { emoji } from './emoji.js';
@@ -8,10 +8,9 @@ import { emoji } from './emoji.js';
 vi.mock('../logger.js');
 
 describe('profile', () => {
-	const mockReply = vi.fn<[content: unknown], Promise<void>>();
-	const mockEmojiName = vi.fn<[], string | undefined>();
-	const mockEmojiURL = vi.fn<[options?: ImageURLOptions | undefined], string | null>();
-	const mockShouldRespondEphemeral = vi.fn<[], boolean | null>();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
+	const mockEmojiName = vi.fn<TextInputCommandContext['options']['getString']>();
+	const mockShouldRespondEphemeral = vi.fn<TextInputCommandContext['options']['getBoolean']>();
 
 	const testEmojiURL = 'https://example.com/emojis/1234567890/abcdef1234567890.png';
 
@@ -38,7 +37,6 @@ describe('profile', () => {
 		} as unknown as TextInputCommandContext;
 
 		mockEmojiName.mockReturnValue('existing emoji');
-		mockEmojiURL.mockReturnValue(testEmojiURL);
 		mockShouldRespondEphemeral.mockReturnValue(true);
 	});
 

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -14,7 +14,7 @@ vi.mock('../constants/meta.js', async () => {
 import { help } from './help.js';
 
 describe('help', () => {
-	const mockReply = vi.fn();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
 	let context: TextInputCommandContext;
 
 	beforeEach(() => {

--- a/src/commands/isCasDown.test.ts
+++ b/src/commands/isCasDown.test.ts
@@ -1,17 +1,15 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, assert, describe, expect, test, vi } from 'vitest';
 
 import { Colors } from 'discord.js';
-import type { EmbedBuilder } from '@discordjs/builders';
-import type { URL } from 'node:url';
 
-const fetchMock = vi.fn<[URL], Promise<Response>>();
+const fetchMock = vi.fn<typeof fetch>();
 vi.stubGlobal('fetch', fetchMock);
 
 // Import the code to test
 import { isCasDown } from './isCasDown.js';
 
 describe('isCasDown', () => {
-	const mockReply = vi.fn<[{ embeds: Array<EmbedBuilder>; ephemeral: boolean }], Promise<void>>();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
 
 	const goodResponse = {
 		status: 200,
@@ -28,13 +26,27 @@ describe('isCasDown', () => {
 		fetchMock.mockResolvedValueOnce(goodResponse);
 		await expect(isCasDown.execute({ reply: mockReply })).resolves.toBeUndefined();
 		expect(mockReply).toHaveBeenCalledOnce();
-		expect(mockReply.mock.calls[0][0].embeds[0].data.color).toBe(Colors.Green);
+		const response = mockReply.mock.calls.at(0)?.at(0);
+		if (!response || typeof response === 'string' || !response.embeds) {
+			assert.fail('Did not reply to interaction with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		const embed = response.embeds.at(0);
+		const embedData = 'toJSON' in embed ? embed.toJSON() : embed;
+		expect(embedData.color).toBe(Colors.Green);
 	});
 
 	test('Returns the failure embed when CAS returns a bad response', async () => {
 		fetchMock.mockResolvedValueOnce(badResponse);
 		await expect(isCasDown.execute({ reply: mockReply })).resolves.toBeUndefined();
 		expect(mockReply).toHaveBeenCalledOnce();
-		expect(mockReply.mock.calls[0][0].embeds[0].data.color).toBe(Colors.Red);
+		const response = mockReply.mock.calls.at(0)?.at(0);
+		if (!response || typeof response === 'string' || !response.embeds) {
+			assert.fail('Did not reply to interaction with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		const embed = response.embeds.at(0);
+		const embedData = 'toJSON' in embed ? embed.toJSON() : embed;
+		expect(embedData.color).toBe(Colors.Red);
 	});
 });

--- a/src/commands/profile.test.ts
+++ b/src/commands/profile.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { GuildMember, ImageURLOptions, User, UserResolvable } from 'discord.js';
+import type { GuildMember, User } from 'discord.js';
 import { DiscordAPIError, EmbedBuilder, userMention } from 'discord.js';
 
 import { DiscordErrorCode } from '../helpers/DiscordErrorCode.js';
@@ -9,14 +9,14 @@ import { profile } from './profile.js';
 vi.mock('../logger.js');
 
 describe('profile', () => {
-	const mockReply = vi.fn<[content: unknown], Promise<void>>();
-	const mockReplyPrivately = vi.fn<[content: string], Promise<void>>();
-	const mockGetUser = vi.fn<[name: string, required?: boolean | undefined], User | null>();
-	const mockGuildMembersFetch = vi.fn<[options: UserResolvable], Promise<GuildMember>>();
-	const mockAvatarURL = vi.fn<[options?: ImageURLOptions | undefined], string | null>();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
+	const mockReplyPrivately = vi.fn<TextInputCommandContext['replyPrivately']>();
+	const mockGetUser = vi.fn<TextInputCommandContext['options']['getUser']>();
+	const mockGuildMembersFetch = vi.fn<TextInputCommandContext['guild']['members']['fetch']>();
+	const mockAvatarURL = vi.fn<User['avatarURL']>();
 
 	const testAvatar = 'https://example.com/avatars/1234567890/abcdef1234567890.png';
-	let context: unknown;
+	let context: TextInputCommandContext;
 	let user: User;
 	let otherUser: User;
 	let botUser: User;

--- a/src/commands/sendtag.test.ts
+++ b/src/commands/sendtag.test.ts
@@ -5,8 +5,8 @@ import type { AutocompleteInteraction } from 'discord.js';
 import { sendtag } from './sendtag.js';
 
 describe('sendtag', () => {
-	const mockReply = vi.fn<[content: string], Promise<void>>();
-	const mockGetString = vi.fn<[name: string, required: true], string>();
+	const mockReply = vi.fn<GuildedCommandContext['reply']>();
+	const mockGetString = vi.fn<GuildedCommandContext['options']['getString']>();
 
 	let context: GuildedCommandContext;
 

--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 import type { DeepMockProxy } from 'vitest-mock-extended';
 import { mockDeep } from 'vitest-mock-extended';
 
@@ -23,25 +23,30 @@ import { db } from '../database/index.js';
 
 describe('stats', () => {
 	const dbMock = db as DeepMockProxy<PrismaClient>;
+	// FIXME vitest-mock-extended's types do not match vitest v2's types
+	// https://github.com/eratio08/vitest-mock-extended/issues/508
 	/* eslint-disable @typescript-eslint/unbound-method */
-	const mockCount = dbMock.scoreboard.count;
-	const mockCreate = dbMock.scoreboard.create;
-	const mockDelete = dbMock.scoreboard.delete;
-	const mockFindFirst = dbMock.scoreboard.findFirst;
-	const mockFindMany = dbMock.scoreboard.findMany;
-	const mockUpdate = dbMock.scoreboard.update;
+	const mockCount = dbMock.scoreboard.count as unknown as Mock<typeof db.scoreboard.count>;
+	const mockCreate = dbMock.scoreboard.create as unknown as Mock<typeof db.scoreboard.create>;
+	const mockDelete = dbMock.scoreboard.delete as unknown as Mock<typeof db.scoreboard.delete>;
+	const mockFindFirst = dbMock.scoreboard.findFirst as unknown as Mock<
+		typeof db.scoreboard.findFirst
+	>;
+	const mockFindMany = dbMock.scoreboard.findMany as unknown as Mock<typeof db.scoreboard.findMany>;
+	const mockUpdate = dbMock.scoreboard.update as unknown as Mock<typeof db.scoreboard.update>;
 	/* eslint-enable @typescript-eslint/unbound-method */
 
 	const mockUserId = 'test-user-id';
 	const mockStatName = 'stats-test';
 	const mockGuildId = 'test-guild-id';
 
-	const mockReply = vi.fn();
-	const mockReplyPrivately = vi.fn();
-	const mockGetString = vi.fn<[name: string], string | null>();
-	const mockGetNumber = vi.fn<[name: string], number | null>();
-	const mockGetSubcommand = vi.fn();
-	const mockGetUser = vi.fn();
+	const mockReply = vi.fn<GuildedCommandContext['reply']>();
+	const mockReplyPrivately = vi.fn<GuildedCommandContext['replyPrivately']>();
+	const mockGetString = vi.fn<GuildedCommandContext['interaction']['options']['getString']>();
+	const mockGetNumber = vi.fn<GuildedCommandContext['interaction']['options']['getNumber']>();
+	const mockGetSubcommand =
+		vi.fn<GuildedCommandContext['interaction']['options']['getSubcommand']>();
+	const mockGetUser = vi.fn<GuildedCommandContext['client']['users']['cache']['get']>();
 	let context: GuildedCommandContext;
 
 	beforeEach(() => {

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ChannelType } from 'discord.js';
+// eslint-disable-next-line import/default, import/no-named-as-default, import/no-named-as-default-member
+import type dectalk from 'dectalk-tts';
 
 // Overwrite dectalk say method
-const dectalkMock = vi.hoisted(() => vi.fn());
+const dectalkMock = vi.hoisted(() => vi.fn<typeof dectalk>());
 vi.mock('dectalk-tts', () => ({ default: dectalkMock }));
 
 // Mock the logger so nothing is printed
@@ -13,13 +15,14 @@ vi.mock('../logger');
 import { Speaker, talk } from './talk.js';
 
 describe('Talk Slash Command', () => {
-	const speakerMock = vi.fn<[], Speaker | null>();
+	const speakerMock = vi.fn<() => Speaker | null>();
 	const message = 'test';
 	let context: TextInputCommandContext;
 	const emptyBuffer: Buffer = Buffer.from([]);
-	const prepareForLongRunningTasksMock = vi.fn();
-	const replyMock = vi.fn();
-	const getStringMock = vi.fn();
+	const prepareForLongRunningTasksMock =
+		vi.fn<TextInputCommandContext['prepareForLongRunningTasks']>();
+	const replyMock = vi.fn<TextInputCommandContext['reply']>();
+	const getStringMock = vi.fn<TextInputCommandContext['options']['getString']>();
 
 	beforeEach(() => {
 		context = {

--- a/src/commands/toTheGallows.test.ts
+++ b/src/commands/toTheGallows.test.ts
@@ -1,6 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { EmbedBuilder, MessageReplyOptions } from 'discord.js';
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { toTheGallows } from './toTheGallows.js';
 
@@ -15,8 +13,8 @@ vi.mock('../constants/meta.js', async () => {
 });
 
 describe('toTheGallows', () => {
-	const mockReply = vi.fn<[MessageReplyOptions]>();
-	const mockGetInteger = vi.fn<[name: string], number | null>();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
+	const mockGetInteger = vi.fn<TextInputCommandContext['options']['getInteger']>();
 	let context: TextInputCommandContext;
 
 	beforeEach(() => {
@@ -38,10 +36,13 @@ describe('toTheGallows', () => {
 		await expect(toTheGallows.execute(context)).resolves.toBeUndefined();
 
 		expect(mockReply).toHaveBeenCalledOnce();
-		const response = mockReply.mock.calls.at(0)?.[0];
-		expect(response?.embeds?.length).toEqual(1);
-		expect(response?.embeds?.at(0)).toBeTypeOf('object');
-		expect(response?.components?.length).toEqual(5);
+		const response = mockReply.mock.calls.at(0)?.at(0);
+		if (!response || typeof response === 'string' || !('embeds' in response)) {
+			assert.fail('Did not reply to interactions with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		expect(response.embeds.at(0)).toBeTypeOf('object');
+		expect(response.components?.length).toEqual(5);
 	});
 
 	test('specifying length and number of guesses always puts the game into the same state', async () => {
@@ -51,9 +52,13 @@ describe('toTheGallows', () => {
 		expect(mockReply).toHaveBeenCalledOnce();
 
 		const response = mockReply.mock.calls.at(0)?.at(0);
-		expect(response?.embeds?.length).toEqual(1);
-		const embed = response?.embeds?.at(0) as EmbedBuilder | undefined;
-		expect(embed?.data).toMatchSnapshot();
-		expect(response?.components?.length).toEqual(5);
+		if (!response || typeof response === 'string' || !('embeds' in response)) {
+			assert.fail('Did not reply to interactions with embeds');
+		}
+		expect(response.embeds.length).toEqual(1);
+		const embed = response.embeds.at(0);
+		const embedData = 'toJSON' in embed ? embed.toJSON() : embed;
+		expect(embedData).toMatchSnapshot();
+		expect(response.components?.length).toEqual(5);
 	});
 });

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { exec } from 'node:child_process';
+
 import type { User } from 'discord.js';
 
 // Mock the logger to prevent extra output
 vi.mock('../logger.js');
 
 // Overwrite the exec function
-const mockExec = vi.hoisted(() => vi.fn());
+const mockExec = vi.hoisted(() => vi.fn<typeof exec>());
 vi.mock('node:child_process', async () => {
 	const cp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
 	return {
@@ -27,8 +29,8 @@ describe('update', () => {
 		username: 'TheCitizen',
 		id: '3',
 	} as unknown as User;
-	const mockReplyPrivately = vi.fn<[content: string], Promise<void>>();
-	const mockEditReply = vi.fn<[content: string], Promise<void>>();
+	const mockReplyPrivately = vi.fn<TextInputCommandContext['replyPrivately']>();
+	const mockEditReply = vi.fn<TextInputCommandContext['editReply']>();
 
 	let context: TextInputCommandContext;
 	let originalAdministrators: string | undefined;

--- a/src/commands/xkcd.test.ts
+++ b/src/commands/xkcd.test.ts
@@ -5,12 +5,9 @@ import { fetchJson } from '../helpers/fetch.js';
 import { HttpStatusCode } from '../helpers/HttpStatusCode.js';
 import { NetworkError } from '../helpers/NetworkError.js';
 
-vi.mock('../helpers/fetch.js', () => ({ fetchJson: vi.fn() }));
+vi.mock('../helpers/fetch.js', () => ({ fetchJson: vi.fn<typeof fetchJson>() }));
 
-const mockedFetchJson = fetchJson as Mock<
-	Parameters<typeof fetchJson>,
-	ReturnType<typeof fetchJson>
->;
+const mockedFetchJson = fetchJson as Mock<typeof fetchJson>;
 
 // Mock the logger so nothing is printed
 vi.mock('../logger.js');
@@ -50,9 +47,9 @@ const badResponse = new NetworkError(HttpStatusCode.BAD_REQUEST);
 import { xkcd } from './xkcd.js';
 
 describe('xkcd', () => {
-	const mockReply = vi.fn();
-	const mockSendTyping = vi.fn();
-	const mockGetInteger = vi.fn();
+	const mockReply = vi.fn<TextInputCommandContext['reply']>();
+	const mockSendTyping = vi.fn<TextInputCommandContext['sendTyping']>();
+	const mockGetInteger = vi.fn<TextInputCommandContext['options']['getInteger']>();
 	let context: TextInputCommandContext;
 
 	beforeEach(() => {

--- a/src/events/index.test.ts
+++ b/src/events/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
 
 // Create a mocked client to track 'on' and 'once' calls
-const mockOn = vi.fn();
-const mockOnce = vi.fn();
+const mockOn = vi.fn<Client['on']>();
+const mockOnce = vi.fn<Client['once']>();
 const MockClient = vi.hoisted(() => {
 	return class {
 		on = mockOn;

--- a/src/events/messageReactionAdd.test.ts
+++ b/src/events/messageReactionAdd.test.ts
@@ -8,9 +8,9 @@ import { messageReactionAdd } from './messageReactionAdd.js';
 vi.mock('../logger.js');
 
 describe('Reaction duplication', () => {
-	const mockResendReact = vi.fn<[], Promise<unknown>>();
+	const mockResendReact = vi.fn<MessageReaction['react']>();
 
-	let mockRandom: MockInstance<[], number>;
+	let mockRandom: MockInstance<typeof Math.random>;
 	let mockReaction: MessageReaction;
 	let mockSender: User;
 

--- a/src/events/ready.test.ts
+++ b/src/events/ready.test.ts
@@ -26,7 +26,8 @@ vi.mock('discord.js', async () => {
 });
 
 // Re-import Client (which is now MockedClient) so we can use it
-import { Client, ClientPresence } from 'discord.js';
+import type { ClientPresence } from 'discord.js';
+import { Client } from 'discord.js';
 const client = new Client({ intents: [] });
 
 // Mock parseArgs so we can control what the args are

--- a/src/events/ready.test.ts
+++ b/src/events/ready.test.ts
@@ -2,7 +2,7 @@ import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 // Create a mocked client to track 'setActivity' calls and provide basic info
-const mockSetActivity = vi.fn();
+const mockSetActivity = vi.fn<NonNullable<Client['user']>['setActivity']>();
 const MockClient = vi.hoisted(() => {
 	return class {
 		user = {
@@ -26,12 +26,12 @@ vi.mock('discord.js', async () => {
 });
 
 // Re-import Client (which is now MockedClient) so we can use it
-import { Client } from 'discord.js';
+import { Client, ClientPresence } from 'discord.js';
 const client = new Client({ intents: [] });
 
 // Mock parseArgs so we can control what the args are
-import type { Args } from '../helpers/parseArgs.js';
-const mockParseArgs = vi.hoisted(() => vi.fn<[], Args>());
+import type { parseArgs } from '../helpers/parseArgs.js';
+const mockParseArgs = vi.hoisted(() => vi.fn<typeof parseArgs>());
 vi.mock('../helpers/parseArgs', () => ({ parseArgs: mockParseArgs }));
 
 // Mock deployCommands so we can track it
@@ -64,7 +64,7 @@ describe('once(ready)', () => {
 		});
 		mockDeployCommands.mockResolvedValue(undefined);
 		mockRevokeCommands.mockResolvedValue(undefined);
-		mockSetActivity.mockReturnValue({});
+		mockSetActivity.mockReturnValue({} as ClientPresence);
 	});
 
 	afterEach(() => {

--- a/src/helpers/actions/messages/replyToMessage.test.ts
+++ b/src/helpers/actions/messages/replyToMessage.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { Message, RepliableInteraction, TextChannel, User } from 'discord.js';
+import type {
+	InteractionResponse,
+	Message,
+	RepliableInteraction,
+	TextChannel,
+	User,
+} from 'discord.js';
 import { ChannelType } from 'discord.js';
 
 // Mock the logger to track output
@@ -10,10 +16,10 @@ import { error as mockLoggerError } from '../../../logger.js';
 import { replyWithPrivateMessage, sendMessageInChannel } from './replyToMessage.js';
 
 describe('Replies', () => {
-	const mockUserSend = vi.fn();
+	const mockUserSend = vi.fn<RepliableInteraction['user']['send']>();
 
 	describe('to interactions', () => {
-		const mockReply = vi.fn();
+		const mockReply = vi.fn<RepliableInteraction['reply']>();
 		let interaction: RepliableInteraction;
 
 		beforeEach(() => {
@@ -128,15 +134,15 @@ describe('Replies', () => {
 	});
 
 	describe('to messages', () => {
-		const mockReply = vi.fn();
-		const mockChannelSend = vi.fn();
+		const mockReply = vi.fn<RepliableInteraction['reply']>();
+		const mockChannelSend = vi.fn<Message['channel']['send']>();
 		let author: User;
 		let message: Message;
 
 		beforeEach(() => {
-			mockReply.mockResolvedValue({});
-			mockChannelSend.mockResolvedValue({});
-			mockUserSend.mockResolvedValue({});
+			mockReply.mockResolvedValue({} as InteractionResponse);
+			mockChannelSend.mockResolvedValue({} as Message<false>);
+			mockUserSend.mockResolvedValue({} as Message<false>);
 			author = {
 				id: 'user-1234',
 				send: mockUserSend,
@@ -232,11 +238,11 @@ describe('Replies', () => {
 });
 
 describe('Cold calls', () => {
-	const mockChannelSend = vi.fn();
+	const mockChannelSend = vi.fn<TextChannel['send']>();
 	let mockChannel: TextChannel;
 
 	beforeEach(() => {
-		mockChannelSend.mockResolvedValue({ id: 'the-message' });
+		mockChannelSend.mockResolvedValue({ id: 'the-message' } as Message<true>);
 		mockChannel = {
 			send: mockChannelSend,
 			type: ChannelType.GuildText,

--- a/src/helpers/actions/revokeCommands.test.ts
+++ b/src/helpers/actions/revokeCommands.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { Collection, OAuth2Guild, type Client, type Guild } from 'discord.js';
+import type { Client, Guild, OAuth2Guild } from 'discord.js';
+import { Collection } from 'discord.js';
 
 // Mock the logger so nothing is printed
 vi.mock('../../logger.js');

--- a/src/helpers/actions/revokeCommands.test.ts
+++ b/src/helpers/actions/revokeCommands.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { Client } from 'discord.js';
+import { Collection, OAuth2Guild, type Client, type Guild } from 'discord.js';
 
 // Mock the logger so nothing is printed
 vi.mock('../../logger.js');
@@ -8,9 +8,9 @@ vi.mock('../../logger.js');
 import { revokeCommands } from './revokeCommands.js';
 
 describe('Command revocations', () => {
-	const mockApplicationCommandsSet = vi.fn();
-	const mockGuildCommandsSet = vi.fn();
-	const mockFetchOauthGuilds = vi.fn();
+	const mockApplicationCommandsSet = vi.fn<NonNullable<Client['application']>['commands']['set']>();
+	const mockGuildCommandsSet = vi.fn<Guild['commands']['set']>();
+	const mockFetchOauthGuilds = vi.fn<Client['guilds']['fetch']>();
 
 	const mockClient = {
 		application: {
@@ -24,28 +24,28 @@ describe('Command revocations', () => {
 	} as unknown as Client;
 
 	beforeEach(() => {
-		mockApplicationCommandsSet.mockResolvedValue(undefined);
-		mockGuildCommandsSet.mockImplementation(vals => Promise.resolve(vals));
-		mockFetchOauthGuilds.mockResolvedValue([
-			{
-				fetch: (): Promise<unknown> =>
-					Promise.resolve({
-						id: 'test-guild1',
-						commands: {
-							set: mockGuildCommandsSet,
-						},
-					}),
-			},
-			{
-				fetch: (): Promise<unknown> =>
-					Promise.resolve({
-						id: 'test-guild2',
-						commands: {
-							set: mockGuildCommandsSet,
-						},
-					}),
-			},
-		]);
+		mockGuildCommandsSet.mockImplementation(() => Promise.resolve(new Collection()));
+		mockFetchOauthGuilds.mockResolvedValue(
+			new Collection<string, OAuth2Guild>()
+				.set('test-guild1', {
+					fetch: () =>
+						Promise.resolve({
+							id: 'test-guild1',
+							commands: {
+								set: mockGuildCommandsSet,
+							},
+						} as unknown as Guild),
+				} as OAuth2Guild)
+				.set('test-guild2', {
+					fetch: () =>
+						Promise.resolve({
+							id: 'test-guild2',
+							commands: {
+								set: mockGuildCommandsSet,
+							},
+						} as unknown as Guild),
+				} as OAuth2Guild)
+		);
 	});
 
 	afterEach(() => {

--- a/src/helpers/actions/verifyCommandDeployments.test.ts
+++ b/src/helpers/actions/verifyCommandDeployments.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { Client } from 'discord.js';
+import type { Client, Guild } from 'discord.js';
 import { Collection, SlashCommandBuilder } from 'discord.js';
 
 const mockAllCommands = vi.hoisted(() => new Map<string, Command>());
@@ -40,8 +40,9 @@ describe('Verify command deployments', () => {
 		},
 	];
 
-	const mockFetchApplicationCommands = vi.fn();
-	const mockFetchGuildCommands = vi.fn();
+	const mockFetchApplicationCommands =
+		vi.fn<NonNullable<Client['application']>['commands']['fetch']>();
+	const mockFetchGuildCommands = vi.fn<Guild['commands']['set']>();
 
 	const mockClient = {
 		application: {
@@ -75,9 +76,11 @@ describe('Verify command deployments', () => {
 		const deployedGlobal = new Collection<string, Command>();
 		const deployedGuild = new Collection<string, Command>();
 		mockFetchApplicationCommands.mockImplementation(() =>
+			// @ts-expect-error Really complicated errors with discord.js types that I don't want to deal with
 			Promise.resolve(deployedGlobal.map(deployableCommand))
 		);
 		mockFetchGuildCommands.mockImplementation(() =>
+			// @ts-expect-error Really complicated errors with discord.js types that I don't want to deal with
 			Promise.resolve(deployedGuild.map(deployableCommand))
 		);
 

--- a/src/helpers/positionsOfUriInText.test.ts
+++ b/src/helpers/positionsOfUriInText.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, test, vi } from 'vitest';
 
+import type { URL } from 'node:url';
+
 // As far as we know, the uriRegex will only match strings that are valid URIs.
 // But in order to test what would happen if not, we need to override the URL.canParse method to
 // return false for a specific string. For all other tests, we want to use the default implementation.
-const canParseMock = vi.hoisted(vi.fn);
+const canParseMock = vi.hoisted(vi.fn<typeof URL.canParse>);
 vi.mock('node:url', async () => {
 	const nodeURL = await vi.importActual<typeof import('node:url')>('node:url');
 	return {
 		...nodeURL,
 		URL: {
+			...nodeURL.URL,
 			canParse: canParseMock.mockImplementation((input: string, base?: string) =>
 				nodeURL.URL.canParse(input, base)
 			),

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -2,8 +2,8 @@ import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 // Create a mocked client to track constructor and 'login' calls
-const mockConstructClient = vi.fn();
-const mockLogin = vi.fn();
+const mockConstructClient = vi.fn<(...args: ReadonlyArray<unknown>) => void>();
+const mockLogin = vi.fn<Client['login']>();
 
 const MockClient = vi.hoisted(() => {
 	return class {
@@ -31,10 +31,7 @@ process.env['DISCORD_TOKEN'] = mockToken;
 // Mock the event handler index so we can track it
 vi.mock('./events/index.js');
 import { registerEventHandlers } from './events/index.js';
-const mockRegisterEventHandlers = registerEventHandlers as Mock<
-	Parameters<typeof registerEventHandlers>,
-	ReturnType<typeof registerEventHandlers>
->;
+const mockRegisterEventHandlers = registerEventHandlers as Mock<typeof registerEventHandlers>;
 
 // Mock the logger to track output
 vi.mock('./logger.js');
@@ -42,6 +39,7 @@ import { error as mockLoggerError } from './logger.js';
 
 // Import the code to test
 import { _main } from './main.js';
+import { Client } from 'discord.js';
 
 // A basic error to test with
 const loginError = new Error('Failed to log in. This is a test.');

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,6 +1,8 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { Client } from 'discord.js';
+
 // Create a mocked client to track constructor and 'login' calls
 const mockConstructClient = vi.fn<(...args: ReadonlyArray<unknown>) => void>();
 const mockLogin = vi.fn<Client['login']>();
@@ -39,7 +41,6 @@ import { error as mockLoggerError } from './logger.js';
 
 // Import the code to test
 import { _main } from './main.js';
-import { Client } from 'discord.js';
 
 // A basic error to test with
 const loginError = new Error('Failed to log in. This is a test.');


### PR DESCRIPTION
### Added

- Generic types to all `vi.fn()` methods

### Changed

- `vitest` dependencies to v2
- Pre-existing `vi.fn()` and `Mock<>` generic types to match the new v2 types

### Fixed

- Type issues from giving generic types to `vi.fn()` methods
- Invalid node exit code CI failure by updating `prisma`
  - See this [stackoverflow question](https://stackoverflow.com/questions/76138323/the-code-argument-must-be-of-type-number-error-in-nestjs-prisma)
  - https://github.com/prisma/prisma/pull/18899