### PR TITLE
Cleanup tests

### DIFF
--- a/src/buttons/hangmanLessButton.test.ts
+++ b/src/buttons/hangmanLessButton.test.ts
@@ -25,7 +25,7 @@ describe('hangmanLessButton', () => {
 	});
 
 	test('updates response to have first (full) page of buttons', async () => {
-		await expect(hangmanLessButton.execute(context)).resolves.toBeUndefined();
+		await hangmanLessButton.execute(context);
 
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const response = mockUpdate.mock.calls.at(0)?.at(0);

--- a/src/buttons/hangmanLetterButton.test.ts
+++ b/src/buttons/hangmanLetterButton.test.ts
@@ -39,7 +39,7 @@ describe('hangmanMoreButton', () => {
 
 	test('guessing a letter updates the game info panel', async () => {
 		const bButton = letterButtons[1];
-		await expect(bButton?.execute(context)).resolves.toBeUndefined();
+		await bButton?.execute(context);
 
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const lastCall = mockUpdate.mock.lastCall as unknown as [

--- a/src/buttons/hangmanMoreButton.test.ts
+++ b/src/buttons/hangmanMoreButton.test.ts
@@ -25,7 +25,7 @@ describe('hangmanMoreButton', () => {
 	});
 
 	test('updates response to have second page of buttons', async () => {
-		await expect(hangmanMoreButton.execute(context)).resolves.toBeUndefined();
+		await hangmanMoreButton.execute(context);
 
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const response = mockUpdate.mock.calls.at(0)?.at(0);

--- a/src/commandContext/followUp.test.ts
+++ b/src/commandContext/followUp.test.ts
@@ -5,7 +5,7 @@ import type { Message, RepliableInteraction } from 'discord.js';
 
 vi.mock('../helpers/actions/messages/replyToMessage.js');
 import { sendMessageInChannel } from '../helpers/actions/messages/replyToMessage.js';
-const mockSendMessageInChannel = sendMessageInChannel as Mock;
+const mockSendMessageInChannel = sendMessageInChannel as Mock<typeof sendMessageInChannel>;
 
 // Mock the logger to track output
 vi.mock('../logger.js');

--- a/src/commandContext/prepareForLongRunningTasks.test.ts
+++ b/src/commandContext/prepareForLongRunningTasks.test.ts
@@ -22,7 +22,7 @@ describe('prepareForLongRunningTasks', () => {
 	});
 
 	test('requests interaction deferrment', async () => {
-		await expect(prepareForLongRunningTasks()).resolves.toBeUndefined();
+		await prepareForLongRunningTasks();
 
 		expect(mockLoggerError).not.toHaveBeenCalled();
 		expect(mockInteractionDeferReply).toHaveBeenCalledOnce();
@@ -30,7 +30,7 @@ describe('prepareForLongRunningTasks', () => {
 	});
 
 	test('requests ephemeral interaction deferrment', async () => {
-		await expect(prepareForLongRunningTasks(true)).resolves.toBeUndefined();
+		await prepareForLongRunningTasks(true);
 
 		expect(mockLoggerError).not.toHaveBeenCalled();
 		expect(mockInteractionDeferReply).toHaveBeenCalledOnce();
@@ -40,7 +40,7 @@ describe('prepareForLongRunningTasks', () => {
 	test('logs an error if deferrment fails', async () => {
 		const testError = new Error('this is a test');
 		mockInteractionDeferReply.mockRejectedValueOnce(testError);
-		await expect(prepareForLongRunningTasks()).resolves.toBeUndefined();
+		await prepareForLongRunningTasks();
 
 		expect(mockInteractionDeferReply).toHaveBeenCalledOnce();
 		expect(mockLoggerError).toHaveBeenCalledOnce();

--- a/src/commandContext/reply.test.ts
+++ b/src/commandContext/reply.test.ts
@@ -19,12 +19,12 @@ describe('public reply', () => {
 	const reply = factory(interaction);
 
 	test('sends public reply to interaction with text', async () => {
-		await expect(reply('yo')).resolves.toBeUndefined();
+		await reply('yo');
 		expect(mockInteractionReply).toHaveBeenCalledWith('yo');
 	});
 
 	test('sends an ephemeral reply to the interaction', async () => {
-		await expect(reply({ content: 'yo in secret', ephemeral: true })).resolves.toBeUndefined();
+		await reply({ content: 'yo in secret', ephemeral: true });
 		expect(mockLoggerError).not.toHaveBeenCalled();
 		expect(mockInteractionReply).toHaveBeenCalledWith({
 			content: 'yo in secret',
@@ -33,13 +33,13 @@ describe('public reply', () => {
 	});
 
 	test('trusts that discord.js defaults to mentioning the other user', async () => {
-		await expect(reply({ content: 'yo', shouldMention: true })).resolves.toBeUndefined();
+		await reply({ content: 'yo', shouldMention: true });
 		expect(mockLoggerError).not.toHaveBeenCalled();
 		expect(mockInteractionReply).toHaveBeenCalledWith({ content: 'yo' });
 	});
 
 	test('requests that the other user not be mentioned', async () => {
-		await expect(reply({ content: 'yo', shouldMention: false })).resolves.toBeUndefined();
+		await reply({ content: 'yo', shouldMention: false });
 		expect(mockLoggerError).not.toHaveBeenCalled();
 		expect(mockInteractionReply).toHaveBeenCalledWith({
 			content: 'yo',
@@ -50,7 +50,7 @@ describe('public reply', () => {
 	test('logs an error if the interaction fails', async () => {
 		const testError = new Error('This is a test');
 		mockInteractionReply.mockRejectedValueOnce(testError);
-		await expect(reply('yo')).resolves.toBeUndefined();
+		await reply('yo');
 		expect(mockLoggerError).toHaveBeenCalledOnce();
 		expect(mockLoggerError).toHaveBeenCalledWith(
 			expect.stringContaining('reply to interaction'),

--- a/src/commandContext/replyPrivately.test.ts
+++ b/src/commandContext/replyPrivately.test.ts
@@ -39,7 +39,7 @@ describe('ephemeral and DM replies', () => {
 	});
 
 	test('sends an ephemeral reply to check DMs', async () => {
-		await expect(replyPrivately('yo DMs', true)).resolves.toBeUndefined();
+		await replyPrivately('yo DMs', true);
 		expect(mockInteractionReply).toHaveBeenCalledWith({
 			content: expect.stringContaining('Check your DMs') as string,
 			ephemeral: true,
@@ -50,7 +50,7 @@ describe('ephemeral and DM replies', () => {
 	test('logs an error if the initial ephemeral reply fails', async () => {
 		const testError = new Error('This is a test');
 		mockInteractionReply.mockRejectedValueOnce(testError);
-		await expect(replyPrivately('yo DMs', true)).resolves.toBeUndefined();
+		await replyPrivately('yo DMs', true);
 		expect(mockInteractionReply).toHaveBeenCalledWith({
 			content: expect.stringContaining('Check your DMs') as string,
 			ephemeral: true,
@@ -62,7 +62,7 @@ describe('ephemeral and DM replies', () => {
 
 	test('logs a notice if the user has DMs turned off', async () => {
 		mockSendDM.mockResolvedValueOnce(false);
-		await expect(replyPrivately('yo DMs', true)).resolves.toBeUndefined();
+		await replyPrivately('yo DMs', true);
 		expect(mockInteractionReply).toHaveBeenCalledWith({
 			content: expect.stringContaining('Check your DMs') as string,
 			ephemeral: true,
@@ -76,7 +76,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately('yo DMs', true)).resolves.toBeUndefined();
+		await replyPrivately('yo DMs', true);
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
 			expect.stringContaining('Check your DMs')
 		);
@@ -87,7 +87,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately({ content: 'yo DMs' }, true)).resolves.toBeUndefined();
+		await replyPrivately({ content: 'yo DMs' }, true);
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
 			expect.stringContaining('Check your DMs')
 		);
@@ -100,7 +100,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately({ content: 'yo' }, true)).resolves.toBeUndefined();
+		await replyPrivately({ content: 'yo' }, true);
 		expect(mockInteractionEditReply).toHaveBeenCalledWith(
 			expect.stringContaining('Check your DMs')
 		);
@@ -113,7 +113,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately('yo in secret')).resolves.toBeUndefined();
+		await replyPrivately('yo in secret');
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
 			content: 'yo in secret',
 			ephemeral: true,
@@ -124,7 +124,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately({ content: 'yo object in secret' })).resolves.toBeUndefined();
+		await replyPrivately({ content: 'yo object in secret' });
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
 			content: 'yo object in secret',
 			ephemeral: true,
@@ -137,7 +137,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately('yo in secret')).resolves.toBeUndefined();
+		await replyPrivately('yo in secret');
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
 			content: 'yo in secret',
 			ephemeral: true,
@@ -152,7 +152,7 @@ describe('ephemeral and DM replies', () => {
 		interaction = { ...interaction, deferred: true } as unknown as RepliableInteraction;
 		replyPrivately = factory(interaction);
 
-		await expect(replyPrivately({ content: 'yo object in secret' })).resolves.toBeUndefined();
+		await replyPrivately({ content: 'yo object in secret' });
 		expect(mockInteractionFollowUp).toHaveBeenCalledWith({
 			content: 'yo object in secret',
 			ephemeral: true,

--- a/src/commandContext/replyPrivately.test.ts
+++ b/src/commandContext/replyPrivately.test.ts
@@ -5,7 +5,7 @@ import type { RepliableInteraction } from 'discord.js';
 
 vi.mock('../helpers/actions/messages/replyToMessage.js');
 import { replyWithPrivateMessage } from '../helpers/actions/messages/replyToMessage.js';
-const mockSendDM = replyWithPrivateMessage as Mock;
+const mockSendDM = replyWithPrivateMessage as Mock<typeof replyWithPrivateMessage>;
 
 // Mock the logger to track output
 vi.mock('../logger.js');

--- a/src/commandContext/sendTyping.test.ts
+++ b/src/commandContext/sendTyping.test.ts
@@ -1,4 +1,3 @@
-import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { RepliableInteraction } from 'discord.js';
@@ -10,12 +9,12 @@ vi.mock('../logger.js');
 import { sendTypingFactory as factory } from './sendTyping.js';
 
 describe('typing indicator', () => {
-	let mockSendTyping: Mock<NonNullable<RepliableInteraction['channel']>['sendTyping']>;
+	const mockSendTyping = vi.fn<NonNullable<RepliableInteraction['channel']>['sendTyping']>();
 	let interaction: RepliableInteraction;
 	let sendTyping: () => void;
 
 	beforeEach(() => {
-		mockSendTyping = vi.fn<NonNullable<RepliableInteraction['channel']>['sendTyping']>();
+		mockSendTyping.mockClear();
 		interaction = {
 			channel: {
 				sendTyping: mockSendTyping,

--- a/src/commandContext/sendTyping.test.ts
+++ b/src/commandContext/sendTyping.test.ts
@@ -25,7 +25,7 @@ describe('typing indicator', () => {
 	});
 
 	test('sends typing indicator', () => {
-		expect(sendTyping()).toBeUndefined();
+		sendTyping();
 		expect(mockSendTyping).toHaveBeenCalledOnce();
 	});
 
@@ -35,7 +35,7 @@ describe('typing indicator', () => {
 			channel: { ...interaction.channel, type: ChannelType.GuildStageVoice },
 		} as unknown as RepliableInteraction;
 		sendTyping = factory(interaction);
-		expect(sendTyping()).toBeUndefined();
+		sendTyping();
 		expect(mockSendTyping).not.toHaveBeenCalled();
 	});
 });

--- a/src/commands/contextMenu/altText.test.ts
+++ b/src/commands/contextMenu/altText.test.ts
@@ -27,7 +27,7 @@ describe('Get Alt Text', () => {
 
 	test('tells the user when there are no images', async () => {
 		const response = 'This message contains no attachments.';
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -38,7 +38,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = 'The attachment in this message has no text description.';
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -52,7 +52,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = 'None of the 2 attachments in this message contains a text description.';
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -69,7 +69,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = 'None of the 3 attachments in this message contains a text description.';
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -81,7 +81,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = `## Image Description\n> ${description}`;
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -101,7 +101,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = `## Image Descriptions\n### Image 1\n> ${description1}\n### Image 2\n> ${description2}\n### Image 3\n> ${description3}`;
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});
@@ -124,7 +124,7 @@ describe('Get Alt Text', () => {
 		} as unknown as Attachment);
 
 		const response = `## Image Descriptions\n### Image 1\n> ${description1}\n### Image 2\n> ${description2}\n### Image 3\n> ${description3}\n### Image 4 has no description`;
-		await expect(altText.execute(context)).resolves.toBeUndefined();
+		await altText.execute(context);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockReplyPrivately).toHaveBeenCalledWith(response);
 	});

--- a/src/commands/contextMenu/fxtwitter.test.ts
+++ b/src/commands/contextMenu/fxtwitter.test.ts
@@ -59,7 +59,7 @@ describe('Fix Twitter Links', () => {
 		async ({ content, result }: { content: string; result: string }) => {
 			context.targetMessage.content = content;
 
-			await expect(fxtwitter.execute(context)).resolves.toBeUndefined();
+			await fxtwitter.execute(context);
 			expect(mockReplyPrivately).toHaveBeenCalledOnce();
 			expect(mockReplyPrivately).toHaveBeenCalledWith(expect.stringContaining(result));
 		}

--- a/src/commands/contextMenu/talk.test.ts
+++ b/src/commands/contextMenu/talk.test.ts
@@ -28,7 +28,7 @@ describe('Talk Context Menu Command', () => {
 	// Because most of the functionality of the talk context menu is actually contained in the talk slash command,
 	// we don't actually have to test much.
 	test('Calls the talkMessage method of the talk slash command', async () => {
-		await expect(talk.execute(context)).resolves.toBeUndefined();
+		await talk.execute(context);
 		expect(speakMock).toHaveBeenCalledOnce();
 	});
 });

--- a/src/commands/emoji.test.ts
+++ b/src/commands/emoji.test.ts
@@ -50,7 +50,7 @@ describe('profile', () => {
 	});
 
 	test('Returns the url of the target emoji ephemerally', async () => {
-		await expect(emoji.execute(context)).resolves.toBeUndefined();
+		await emoji.execute(context);
 
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({
@@ -67,7 +67,7 @@ describe('profile', () => {
 
 	test('Returns the url of the target emoji ephemerally with undefined respondEphemeral', async () => {
 		mockShouldRespondEphemeral.mockReturnValue(null);
-		await expect(emoji.execute(context)).resolves.toBeUndefined();
+		await emoji.execute(context);
 
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({
@@ -84,7 +84,7 @@ describe('profile', () => {
 
 	test('Returns the url of the target emoji non-ephemerally', async () => {
 		mockShouldRespondEphemeral.mockReturnValue(false);
-		await expect(emoji.execute(context)).resolves.toBeUndefined();
+		await emoji.execute(context);
 
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -26,7 +26,7 @@ describe('help', () => {
 	test('presents an ephemeral embed with general info', async () => {
 		context = { ...context, source: 'dm' } as unknown as TextInputCommandContext;
 
-		await expect(help.execute(context)).resolves.toBeUndefined();
+		await help.execute(context);
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({
 			embeds: [expect.objectContaining({})],

--- a/src/commands/isCasDown.test.ts
+++ b/src/commands/isCasDown.test.ts
@@ -24,7 +24,7 @@ describe('isCasDown', () => {
 
 	test('Returns the success embed when CAS returns a good response', async () => {
 		fetchMock.mockResolvedValueOnce(goodResponse);
-		await expect(isCasDown.execute({ reply: mockReply })).resolves.toBeUndefined();
+		await isCasDown.execute({ reply: mockReply });
 		expect(mockReply).toHaveBeenCalledOnce();
 		const response = mockReply.mock.calls.at(0)?.at(0);
 		if (!response || typeof response === 'string' || !response.embeds) {
@@ -38,7 +38,7 @@ describe('isCasDown', () => {
 
 	test('Returns the failure embed when CAS returns a bad response', async () => {
 		fetchMock.mockResolvedValueOnce(badResponse);
-		await expect(isCasDown.execute({ reply: mockReply })).resolves.toBeUndefined();
+		await isCasDown.execute({ reply: mockReply });
 		expect(mockReply).toHaveBeenCalledOnce();
 		const response = mockReply.mock.calls.at(0)?.at(0);
 		if (!response || typeof response === 'string' || !response.embeds) {

--- a/src/commands/profile.test.ts
+++ b/src/commands/profile.test.ts
@@ -129,7 +129,7 @@ describe('profile', () => {
 	});
 
 	test("Returns the url of the supplied user's profile picture", async () => {
-		await expect(profile.execute(context)).resolves.toBeUndefined();
+		await profile.execute(context);
 		expect(mockReplyPrivately).not.toHaveBeenCalled();
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({
@@ -162,7 +162,7 @@ describe('profile', () => {
 			}
 			mockGuildMembersFetch.mockResolvedValue(user as unknown as GuildMember);
 
-			await expect(profile.execute(context)).resolves.toBeUndefined();
+			await profile.execute(context);
 			expect(mockReplyPrivately).not.toHaveBeenCalled();
 			expect(mockReply).toHaveBeenCalledOnce();
 			expect(mockReply).toHaveBeenCalledWith({
@@ -187,7 +187,7 @@ describe('profile', () => {
 		mockGetUser.mockReturnValue(botUser);
 		mockGuildMembersFetch.mockResolvedValue(botUser as unknown as GuildMember);
 
-		await expect(profile.execute(context)).resolves.toBeUndefined();
+		await profile.execute(context);
 		expect(mockReplyPrivately).not.toHaveBeenCalled();
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({

--- a/src/commands/sendtag.test.ts
+++ b/src/commands/sendtag.test.ts
@@ -25,7 +25,6 @@ describe('sendtag', () => {
 			},
 		} as unknown as GuildedCommandContext;
 
-		mockReply.mockResolvedValue(undefined);
 		mockGetString.mockReturnValue('');
 	});
 

--- a/src/commands/sendtag.test.ts
+++ b/src/commands/sendtag.test.ts
@@ -31,7 +31,7 @@ describe('sendtag', () => {
 	test('presents an response with the given option string', async () => {
 		const value = 'lorem ipsum';
 		mockGetString.mockReturnValue(value);
-		await expect(sendtag.execute(context)).resolves.toBeUndefined();
+		await sendtag.execute(context);
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith(`You requested the '${value}' tag!`);
 	});

--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -84,7 +84,7 @@ describe('stats', () => {
 		});
 
 		test('begins tracking a stat', async () => {
-			await expect(stats.execute(context)).resolves.toBeUndefined();
+			await stats.execute(context);
 			expect(mockCreate).toHaveBeenCalledOnce();
 			expect(mockCreate).toHaveBeenCalledWith({
 				data: {
@@ -121,7 +121,7 @@ describe('stats', () => {
 		});
 
 		test('score is added', async () => {
-			await expect(stats.execute(context)).resolves.toBeUndefined();
+			await stats.execute(context);
 
 			expect(mockUpdate).toHaveBeenCalledOnce();
 			expect(mockUpdate).toHaveBeenCalledWith({
@@ -153,7 +153,7 @@ describe('stats', () => {
 				} as unknown as Scoreboard,
 			]);
 
-			await expect(stats.execute(context)).resolves.toBeUndefined();
+			await stats.execute(context);
 			expect(mockReplyPrivately).toHaveBeenCalled();
 		});
 	});
@@ -169,7 +169,7 @@ describe('stats', () => {
 		});
 
 		test('stops tracking a stat', async () => {
-			await expect(stats.execute(context)).resolves.toBeUndefined();
+			await stats.execute(context);
 			expect(mockDelete).toHaveBeenCalledOnce();
 			expect(mockDelete).toHaveBeenCalledWith({
 				where: {
@@ -203,7 +203,7 @@ describe('stats', () => {
 		});
 
 		test('replies with a leaderboard', async () => {
-			await expect(stats.execute(context)).resolves.toBeUndefined();
+			await stats.execute(context);
 
 			expect(mockReply).toHaveBeenCalled();
 		});

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -54,13 +54,13 @@ describe('Talk Slash Command', () => {
 	});
 
 	test('Prepares for long-running tasks and resolves interaction', async () => {
-		await expect(talk.execute(context)).resolves.toBeUndefined();
+		await talk.execute(context);
 		expect(prepareForLongRunningTasksMock).toHaveBeenCalledOnce();
 		expect(replyMock).toHaveBeenCalledOnce();
 	});
 
 	test('Calls dectalk-tts module to generate wav buffer', async () => {
-		await expect(talk.execute(context)).resolves.toBeUndefined();
+		await talk.execute(context);
 		expect(dectalkMock).toHaveBeenCalledOnce();
 		expect(dectalkMock).toHaveBeenCalledWith(message);
 	});
@@ -69,7 +69,7 @@ describe('Talk Slash Command', () => {
 		const name = Speaker.Paul;
 		speakerMock.mockReturnValueOnce(name);
 
-		await expect(talk.execute(context)).resolves.toBeUndefined();
+		await talk.execute(context);
 		expect(dectalkMock).toHaveBeenCalledWith(`[:name ${name}] ${message}`);
 	});
 
@@ -78,7 +78,7 @@ describe('Talk Slash Command', () => {
 			...context,
 			channel: { type: ChannelType.GuildText },
 		} as unknown as TextInputCommandContext;
-		await expect(talk.execute(context)).resolves.toBeUndefined();
+		await talk.execute(context);
 		expect(replyMock).toHaveBeenCalledWith({
 			files: [
 				{
@@ -107,7 +107,7 @@ describe('Talk Slash Command', () => {
 	// 		...context,
 	// 		channel: { type: ChannelType.GuildVoice },
 	// 	} as unknown as TextInputCommandContext;
-	// 	await expect(talk.execute(context)).resolves.toBeUndefined();
+	// 	await talk.execute(context);
 	// 	expect(mockReply).toHaveBeenCalledWith({
 	// 		content: message,
 	// 	});

--- a/src/commands/toTheGallows.test.ts
+++ b/src/commands/toTheGallows.test.ts
@@ -33,7 +33,7 @@ describe('toTheGallows', () => {
 	});
 
 	test('begins a game of evil hangman', async () => {
-		await expect(toTheGallows.execute(context)).resolves.toBeUndefined();
+		await toTheGallows.execute(context);
 
 		expect(mockReply).toHaveBeenCalledOnce();
 		const response = mockReply.mock.calls.at(0)?.at(0);
@@ -47,7 +47,7 @@ describe('toTheGallows', () => {
 
 	test('specifying length and number of guesses always puts the game into the same state', async () => {
 		mockGetInteger.mockReturnValue(4);
-		await expect(toTheGallows.execute(context)).resolves.toBeUndefined();
+		await toTheGallows.execute(context);
 
 		expect(mockReply).toHaveBeenCalledOnce();
 

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -59,7 +59,7 @@ describe('update', () => {
 	});
 
 	test('can be used by Bot admins', async () => {
-		await expect(update.execute(context)).resolves.toBeUndefined();
+		await update.execute(context);
 		expect(mockExec).toHaveBeenCalledTimes(2);
 		expect(mockReplyPrivately).toHaveBeenCalledOnce();
 		expect(mockEditReply).toHaveBeenCalledOnce();

--- a/src/commands/xkcd.test.ts
+++ b/src/commands/xkcd.test.ts
@@ -84,7 +84,7 @@ describe('xkcd', () => {
 	test('Returning an embed with the latest comic when no number is given', async () => {
 		mockedFetchJson.mockResolvedValue(latestGood);
 		mockGetInteger.mockReturnValueOnce(null);
-		await expect(xkcd.execute(context)).resolves.toBeUndefined();
+		await xkcd.execute(context);
 		expect(mockSendTyping).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({
@@ -97,7 +97,7 @@ describe('xkcd', () => {
 		mockedFetchJson.mockResolvedValue(chosen);
 		mockedFetchJson.mockResolvedValueOnce(latestGood);
 		mockGetInteger.mockReturnValueOnce(chosen.num);
-		await expect(xkcd.execute(context)).resolves.toBeUndefined();
+		await xkcd.execute(context);
 		expect(mockSendTyping).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledOnce();
 		expect(mockReply).toHaveBeenCalledWith({

--- a/src/events/error.test.ts
+++ b/src/events/error.test.ts
@@ -11,8 +11,8 @@ import { error } from './error.js';
 const mockClientError = new Error('This is a test error');
 
 describe('on(error)', () => {
-	test('logs client errors', () => {
-		error.execute(mockClientError);
+	test('logs client errors', async () => {
+		await error.execute(mockClientError);
 		expect(mockLoggerError).toHaveBeenCalledWith(
 			expect.stringContaining('client error'),
 			mockClientError

--- a/src/events/error.test.ts
+++ b/src/events/error.test.ts
@@ -12,7 +12,7 @@ const mockClientError = new Error('This is a test error');
 
 describe('on(error)', () => {
 	test('logs client errors', () => {
-		expect(error.execute(mockClientError)).toBeUndefined();
+		error.execute(mockClientError);
 		expect(mockLoggerError).toHaveBeenCalledWith(
 			expect.stringContaining('client error'),
 			mockClientError

--- a/src/events/index.test.ts
+++ b/src/events/index.test.ts
@@ -60,10 +60,9 @@ describe('allEvents', () => {
 			once: false,
 			execute: () => undefined,
 		};
-		expect(_add(fakeReadyEvent)).toBeUndefined();
-		expect(_add(fakeMessageEvent)).toBeUndefined();
-
-		expect(registerEventHandlers(client)).toBeUndefined();
+		_add(fakeReadyEvent);
+		_add(fakeMessageEvent);
+		registerEventHandlers(client);
 
 		expect(mockOnce).toHaveBeenCalledWith(fakeReadyEvent.name, fakeReadyEvent.execute);
 		expect(mockOn).toHaveBeenCalledWith(fakeMessageEvent.name, fakeMessageEvent.execute);

--- a/src/events/interactionCreate.test.ts
+++ b/src/events/interactionCreate.test.ts
@@ -228,7 +228,7 @@ describe('on(interactionCreate)', () => {
 				throw interactionError;
 			}) as Interaction['isCommand'];
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockLoggerError).toHaveBeenCalledWith(
 				expect.stringContaining('handle interaction'),
 				interactionError
@@ -239,7 +239,7 @@ describe('on(interactionCreate)', () => {
 			const interaction = defaultInteraction();
 			interaction.isCommand = ((): boolean => false) as Interaction['isCommand'];
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 		});
 
@@ -247,7 +247,7 @@ describe('on(interactionCreate)', () => {
 			const interaction = defaultInteraction();
 			interaction.user.bot = true;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 		});
 
@@ -255,7 +255,7 @@ describe('on(interactionCreate)', () => {
 			const interaction = defaultInteraction();
 			interaction.user.id = selfUid;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 		});
 
@@ -263,14 +263,14 @@ describe('on(interactionCreate)', () => {
 			const interaction = defaultInteraction() as CommandInteraction;
 			interaction.commandName = 'nop';
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 		});
 
 		test('calls the `execute` method of a global command from a guild', async () => {
 			const interaction = defaultInteraction();
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).toHaveBeenCalledOnce();
 		});
 
@@ -286,7 +286,7 @@ describe('on(interactionCreate)', () => {
 				member: null,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).toHaveBeenCalledOnce();
 		});
 
@@ -294,7 +294,7 @@ describe('on(interactionCreate)', () => {
 			const interaction = defaultInteraction() as CommandInteraction;
 			interaction.commandName = mockGuildedCommand.info.name;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGuildedExecute).toHaveBeenCalledOnce();
 		});
 
@@ -313,7 +313,7 @@ describe('on(interactionCreate)', () => {
 				reply: mockInteractionReply,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockInteractionReply).toHaveBeenCalledWith({
 				content: "Can't do that here",
@@ -329,7 +329,7 @@ describe('on(interactionCreate)', () => {
 				reply: mockInteractionReply,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionReply).toHaveBeenCalledOnce();
 		});
 
@@ -341,7 +341,7 @@ describe('on(interactionCreate)', () => {
 				reply: mockInteractionReply,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionReply).toHaveBeenCalledOnce();
 		});
 
@@ -353,7 +353,7 @@ describe('on(interactionCreate)', () => {
 				reply: mockInteractionReply,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionReply).toHaveBeenCalledOnce();
 
 			const lastCall = mockInteractionReply.mock.lastCall as unknown as [
@@ -372,7 +372,7 @@ describe('on(interactionCreate)', () => {
 				isMessageContextMenuCommand: (): boolean => true,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionReply).toHaveBeenCalledOnce();
 		});
 
@@ -385,7 +385,7 @@ describe('on(interactionCreate)', () => {
 				isUserContextMenuCommand: (): boolean => true,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionReply).toHaveBeenCalledOnce();
 		});
 
@@ -398,7 +398,7 @@ describe('on(interactionCreate)', () => {
 				editReply: mockInteractionEditReply,
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockInteractionEditReply).toHaveBeenCalledOnce();
 		});
 
@@ -418,7 +418,7 @@ describe('on(interactionCreate)', () => {
 				},
 			};
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockChannelFetch).toHaveBeenCalledOnce();
 		});
 
@@ -430,7 +430,7 @@ describe('on(interactionCreate)', () => {
 				commandName: mockUserContextMenuCommand.info.name,
 			} as UserContextMenuCommandInteraction;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockLoggerError).toHaveBeenCalledWith(
 				expect.stringContaining('handle interaction'),
@@ -446,7 +446,7 @@ describe('on(interactionCreate)', () => {
 				commandName: mockMessageContextMenuCommand.info.name,
 			} as UserContextMenuCommandInteraction;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockLoggerError).toHaveBeenCalledWith(
 				expect.stringContaining('handle interaction'),
@@ -465,7 +465,7 @@ describe('on(interactionCreate)', () => {
 				commandName: mockUserContextMenuCommand.info.name,
 			} as UserContextMenuCommandInteraction;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGuildMembersFetch).toHaveBeenCalledWith(interaction.targetId);
 			expect(mockGlobalExecute).toHaveBeenCalledOnce();
 		});
@@ -482,7 +482,7 @@ describe('on(interactionCreate)', () => {
 				commandName: mockUserContextMenuCommand.info.name,
 			} as UserContextMenuCommandInteraction;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGuildMembersFetch).not.toHaveBeenCalled();
 			expect(mockGlobalExecute).toHaveBeenCalledOnce();
 		});
@@ -498,7 +498,7 @@ describe('on(interactionCreate)', () => {
 				commandName: mockMessageContextMenuCommand.info.name,
 			} as MessageContextMenuCommandInteraction;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).toHaveBeenCalledOnce();
 		});
 	});
@@ -523,7 +523,7 @@ describe('on(interactionCreate)', () => {
 		test('returns zero results if the command is not found', async () => {
 			interaction.commandName = 'nop';
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -534,7 +534,7 @@ describe('on(interactionCreate)', () => {
 		test('returns zero results if the command is a message context menu command', async () => {
 			interaction.commandName = mockMessageContextMenuCommand.info.name;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -545,7 +545,7 @@ describe('on(interactionCreate)', () => {
 		test('returns zero results if the command is a user context menu command', async () => {
 			interaction.commandName = mockUserContextMenuCommand.info.name;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -556,7 +556,7 @@ describe('on(interactionCreate)', () => {
 		test('returns zero results if the command has no autocomplete handler', async () => {
 			interaction.commandName = mockGlobalCommand.info.name;
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -565,7 +565,7 @@ describe('on(interactionCreate)', () => {
 		});
 
 		test("responds with the command's autocomplete values", async () => {
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -578,7 +578,7 @@ describe('on(interactionCreate)', () => {
 				throw new Error('test error');
 			});
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -593,7 +593,7 @@ describe('on(interactionCreate)', () => {
 			});
 			mockRespond.mockRejectedValueOnce(new Error('test error about the error'));
 
-			await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+			await interactionCreate.execute(interaction);
 			expect(mockGlobalExecute).not.toHaveBeenCalled();
 			expect(mockGuildedExecute).not.toHaveBeenCalled();
 			expect(mockRespond).toHaveBeenCalledOnce();
@@ -611,7 +611,7 @@ describe('on(interactionCreate)', () => {
 			isButton: (): boolean => true,
 		} as ButtonInteraction;
 
-		await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+		await interactionCreate.execute(interaction);
 		expect(mockGlobalExecute).not.toHaveBeenCalled();
 	});
 
@@ -623,7 +623,7 @@ describe('on(interactionCreate)', () => {
 			isButton: (): boolean => true,
 		} as ButtonInteraction;
 
-		await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+		await interactionCreate.execute(interaction);
 		expect(mockGlobalExecute).toHaveBeenCalledOnce();
 	});
 
@@ -637,7 +637,7 @@ describe('on(interactionCreate)', () => {
 			reply: mockInteractionReply,
 		};
 
-		await expect(interactionCreate.execute(interaction)).resolves.toBeUndefined();
+		await interactionCreate.execute(interaction);
 		expect(mockInteractionReply).toHaveBeenCalledOnce();
 	});
 });

--- a/src/events/messageReactionAdd.test.ts
+++ b/src/events/messageReactionAdd.test.ts
@@ -46,43 +46,43 @@ describe('Reaction duplication', () => {
 	});
 
 	test("sometimes duplicates a user's react", async () => {
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).toHaveBeenCalledOnce();
 	});
 
 	test("sometimes ignores a user's react", async () => {
 		mockRandom.mockReturnValue(0.5);
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 
 	test('ignores emoji with an empty name', async () => {
 		mockReaction.emoji.name = '';
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 
 	test('ignores emoji with a null name', async () => {
 		mockReaction.emoji.name = null;
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 
 	test('ignores bot reacts', async () => {
 		mockSender.bot = true;
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 
 	test("ignores the bot's own reacts", async () => {
 		mockReaction.me = true;
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 
 	test('ignores :star:', async () => {
 		mockReaction.emoji.name = '⭐';
-		await expect(messageReactionAdd.execute(mockReaction, mockSender)).resolves.toBeUndefined();
+		await messageReactionAdd.execute(mockReaction, mockSender);
 		expect(mockResendReact).not.toHaveBeenCalled();
 	});
 });

--- a/src/events/ready.test.ts
+++ b/src/events/ready.test.ts
@@ -48,7 +48,9 @@ const mockRevokeCommands = revokeCommands as Mock<typeof revokeCommands>;
 // Mock verifyCommandDeployments so we can track it
 vi.mock('../helpers/actions/verifyCommandDeployments.js');
 import { verifyCommandDeployments } from '../helpers/actions/verifyCommandDeployments.js';
-const mockVerifyCommandDeployments = verifyCommandDeployments as Mock<typeof verifyCommandDeployments>;
+const mockVerifyCommandDeployments = verifyCommandDeployments as Mock<
+	typeof verifyCommandDeployments
+>;
 
 // Mock the logger so nothing is printed
 vi.mock('../logger.js');
@@ -63,8 +65,6 @@ describe('once(ready)', () => {
 			deploy: false,
 			revoke: false,
 		});
-		mockDeployCommands.mockResolvedValue(undefined);
-		mockRevokeCommands.mockResolvedValue(undefined);
 		mockSetActivity.mockReturnValue({} as ClientPresence);
 	});
 

--- a/src/events/ready.test.ts
+++ b/src/events/ready.test.ts
@@ -38,17 +38,17 @@ vi.mock('../helpers/parseArgs', () => ({ parseArgs: mockParseArgs }));
 // Mock deployCommands so we can track it
 vi.mock('../helpers/actions/deployCommands.js');
 import { deployCommands } from '../helpers/actions/deployCommands.js';
-const mockDeployCommands = deployCommands as Mock;
+const mockDeployCommands = deployCommands as Mock<typeof deployCommands>;
 
 // Mock revokeCommands so we can track it
 vi.mock('../helpers/actions/revokeCommands.js');
 import { revokeCommands } from '../helpers/actions/revokeCommands.js';
-const mockRevokeCommands = revokeCommands as Mock;
+const mockRevokeCommands = revokeCommands as Mock<typeof revokeCommands>;
 
 // Mock verifyCommandDeployments so we can track it
 vi.mock('../helpers/actions/verifyCommandDeployments.js');
 import { verifyCommandDeployments } from '../helpers/actions/verifyCommandDeployments.js';
-const mockVerifyCommandDeployments = verifyCommandDeployments as Mock;
+const mockVerifyCommandDeployments = verifyCommandDeployments as Mock<typeof verifyCommandDeployments>;
 
 // Mock the logger so nothing is printed
 vi.mock('../logger.js');

--- a/src/events/ready.test.ts
+++ b/src/events/ready.test.ts
@@ -77,7 +77,7 @@ describe('once(ready)', () => {
 			deploy: false,
 			revoke: false,
 		});
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockDeployCommands).not.toHaveBeenCalled();
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
@@ -87,7 +87,7 @@ describe('once(ready)', () => {
 			deploy: true,
 			revoke: false,
 		});
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockDeployCommands).toHaveBeenCalledWith(client);
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
@@ -97,7 +97,7 @@ describe('once(ready)', () => {
 			deploy: false,
 			revoke: true,
 		});
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockDeployCommands).not.toHaveBeenCalled();
 		expect(mockRevokeCommands).toHaveBeenCalledWith(client);
 	});
@@ -107,18 +107,18 @@ describe('once(ready)', () => {
 			deploy: true,
 			revoke: true,
 		});
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockDeployCommands).toHaveBeenCalledWith(client);
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
 
 	test('verifies command deployments', async () => {
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockVerifyCommandDeployments).toHaveBeenCalledWith(client);
 	});
 
 	test('sets user activity', async () => {
-		await expect(ready.execute(client)).resolves.toBeUndefined();
+		await ready.execute(client);
 		expect(mockSetActivity).toHaveBeenCalledOnce();
 	});
 });

--- a/src/helpers/actions/deployCommands.test.ts
+++ b/src/helpers/actions/deployCommands.test.ts
@@ -114,7 +114,7 @@ describe('Command deployments', () => {
 
 	test('does no deployments if there are no commands to deploy', async () => {
 		mockAllCommands.clear();
-		await expect(deployCommands(mockClient)).resolves.toBeUndefined();
+		await deployCommands(mockClient);
 		expect(mockRevokeCommands).toHaveBeenCalledOnce();
 		expect(mockApplicationCommandsSet).not.toHaveBeenCalled();
 		expect(mockGuildCommandsSet).not.toHaveBeenCalled();
@@ -132,14 +132,14 @@ describe('Command deployments', () => {
 
 	test('continues deployments if global commands fail to deploy', async () => {
 		mockApplicationCommandsSet.mockRejectedValueOnce(new Error('This is a test'));
-		await expect(deployCommands(mockClient)).resolves.toBeUndefined();
+		await deployCommands(mockClient);
 		expect(mockApplicationCommandsSet).toHaveBeenCalledOnce();
 		expect(mockGuildCommandsSet).toHaveBeenCalledOnce();
 	});
 
 	test('continues deployments if guild-bound commands fail to deploy', async () => {
 		mockGuildCommandsSet.mockRejectedValueOnce(new Error('This is a test'));
-		await expect(deployCommands(mockClient)).resolves.toBeUndefined();
+		await deployCommands(mockClient);
 		expect(mockApplicationCommandsSet).toHaveBeenCalledOnce();
 		expect(mockGuildCommandsSet).toHaveBeenCalledOnce();
 	});

--- a/src/helpers/actions/deployCommands.test.ts
+++ b/src/helpers/actions/deployCommands.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../commands/index.js', () => ({
 
 vi.mock('./revokeCommands.js');
 import { revokeCommands } from './revokeCommands.js';
-const mockRevokeCommands = revokeCommands as Mock;
+const mockRevokeCommands = revokeCommands as Mock<typeof revokeCommands>;
 
 import { deployCommands } from './deployCommands.js';
 

--- a/src/helpers/actions/deployCommands.test.ts
+++ b/src/helpers/actions/deployCommands.test.ts
@@ -35,7 +35,6 @@ describe('Command deployments', () => {
 	} as unknown as Client;
 
 	beforeEach(() => {
-		mockRevokeCommands.mockResolvedValue(undefined);
 		mockGuildCommandsSet.mockImplementation(() => Promise.resolve(new Collection()));
 		mockFetchOauthGuilds.mockResolvedValue(
 			new Collection<string, OAuth2Guild>().set('test-guild1', {

--- a/src/helpers/actions/messages/replyToMessage.test.ts
+++ b/src/helpers/actions/messages/replyToMessage.test.ts
@@ -23,8 +23,8 @@ describe('Replies', () => {
 		let interaction: RepliableInteraction;
 
 		beforeEach(() => {
-			mockReply.mockResolvedValue({});
-			mockUserSend.mockResolvedValue({});
+			mockReply.mockResolvedValue({} as InteractionResponse);
+			mockUserSend.mockResolvedValue({} as Message<false>);
 			interaction = {
 				user: {
 					id: 'user-1234',

--- a/src/helpers/actions/revokeCommands.test.ts
+++ b/src/helpers/actions/revokeCommands.test.ts
@@ -54,12 +54,12 @@ describe('Command revocations', () => {
 	});
 
 	test('clears global commands', async () => {
-		await expect(revokeCommands(mockClient)).resolves.toBeUndefined();
+		await revokeCommands(mockClient);
 		expect(mockApplicationCommandsSet).toHaveBeenCalledOnce();
 	});
 
 	test('clears commands for each guild', async () => {
-		await expect(revokeCommands(mockClient)).resolves.toBeUndefined();
+		await revokeCommands(mockClient);
 		expect(mockGuildCommandsSet).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/helpers/actions/verifyCommandDeployments.test.ts
+++ b/src/helpers/actions/verifyCommandDeployments.test.ts
@@ -100,7 +100,7 @@ describe('Verify command deployments', () => {
 
 	describe('Guild commands', () => {
 		test('does nothing if the actual commands match expectations', async () => {
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).not.toHaveBeenCalled();
 		});
@@ -108,7 +108,7 @@ describe('Verify command deployments', () => {
 		test('logs a warning if the number of commands differs', async () => {
 			mockAllCommands.delete('arthur');
 
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).toHaveBeenCalledWith(
 				expect.stringContaining("commands in guild 'guild1' differ")
@@ -124,7 +124,7 @@ describe('Verify command deployments', () => {
 				execute: () => undefined,
 			});
 
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchGuildCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).toHaveBeenCalledWith(
 				expect.stringContaining("commands in guild 'guild1' differ")
@@ -137,7 +137,7 @@ describe('Verify command deployments', () => {
 
 	describe('Global commands', () => {
 		test('does nothing if the actual commands match expectations', async () => {
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).not.toHaveBeenCalled();
 		});
@@ -145,7 +145,7 @@ describe('Verify command deployments', () => {
 		test('logs a warning if the number of commands differs', async () => {
 			mockAllCommands.delete('zaphod');
 
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('commands differ'));
 			expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('Expected 1'));
@@ -159,7 +159,7 @@ describe('Verify command deployments', () => {
 				execute: () => undefined,
 			});
 
-			await expect(verifyCommandDeployments(mockClient)).resolves.toBeUndefined();
+			await verifyCommandDeployments(mockClient);
 			expect(mockFetchApplicationCommands).toHaveBeenCalledOnce();
 			expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('commands differ'));
 			expect(mockLoggerWarn).toHaveBeenCalledWith(

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -47,7 +47,6 @@ const loginError = new Error('Failed to log in. This is a test.');
 
 describe('main', () => {
 	beforeEach(() => {
-		mockConstructClient.mockReturnValue(undefined);
 		mockLogin.mockResolvedValue(mockToken);
 	});
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -55,7 +55,7 @@ describe('main', () => {
 	});
 
 	test('disables @everyone pings', async () => {
-		await expect(_main()).resolves.toBeUndefined();
+		await _main();
 		expect(mockConstructClient).toHaveBeenCalledWith(
 			expect.objectContaining({
 				allowedMentions: {
@@ -67,18 +67,18 @@ describe('main', () => {
 	});
 
 	test('calls registerEventHandlers', async () => {
-		await expect(_main()).resolves.toBeUndefined();
+		await _main();
 		expect(mockRegisterEventHandlers).toHaveBeenCalledWith(new MockClient());
 	});
 
 	test('calls login', async () => {
-		await expect(_main()).resolves.toBeUndefined();
+		await _main();
 		expect(mockLogin).toHaveBeenCalledWith(mockToken);
 	});
 
 	test('reports login errors', async () => {
 		mockLogin.mockRejectedValueOnce(loginError);
-		await expect(_main()).resolves.toBeUndefined();
+		await _main();
 		expect(mockLoggerError).toHaveBeenCalledWith(expect.stringContaining('log in'), loginError);
 	});
 });


### PR DESCRIPTION
Follow up to #129 

---

### Added

- Generics for all `Mock<>` types

### Removed

- Unnecessary mock implementations and return values, like `undefined`
- `.toBeUndefined()` assertions on methods that return `void` or `Promise<void>`
  - Usually we're just testing that they don't throw an error, so `expect()` is unnecessary
  - For rejected promises, the error is more readable when not wrapped in an `expect()`