### PR TITLE
feat: Add CI workflow to push code to Codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,22 @@
+name: Code Mirror
+# Pushes new code to external mirrors
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push to Codeberg
+        uses: yesolutions/mirror-action@v0.7.0
+        with:
+          REMOTE: 'https://codeberg.org/BYU-CS-Discord/CSBot.git'
+          GIT_USERNAME: byu-cs-discord-mirror-bot
+          GIT_PASSWORD: ${{ secrets.CODEBERG_PUSH_KEY }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project is meant as a successor to [Ze-Kaiser](https://github.com/ArkenStor
 - [**EmmaChase**](https://github.com/EmmaChase)
 - [**TheZealotAlmighty**](https://github.com/TheZealotAlmighty)
 
+A read-only code mirror for this project exists [on Codeberg](https://codeberg.org/BYU-CS-Discord/CSBot/).
+
 ## Authors & Contributors
 
 These users contributed various things over time directly to this codebase. This list is ordered roughly by when users first contributed code. We add to this list as people contribute.
@@ -29,8 +31,6 @@ These users contributed various things over time directly to this codebase. This
 This project is entirely open-source. Do with it what you will. If you're willing to help us improve this project, consider [filing an issue](https://github.com/BYU-CS-Discord/CSBot/issues/new/choose).
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for ways to contribute.
-
-A read-only code mirror also exists [on Codeberg](https://codeberg.org/BYU-CS-Discord/CSBot/).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This project is entirely open-source. Do with it what you will. If you're willin
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for ways to contribute.
 
+A read-only code mirror also exists [on Codeberg](https://codeberg.org/BYU-CS-Discord/CSBot/).
+
 ## License
 
 This project's source is licensed under the [BSD Zero Clause License](LICENSE). All contributions to this project's source may be used, copied, modified, and/or distributed for any purpose.


### PR DESCRIPTION
In the interest of not "keeping all our eggs in one basket", and in case GitHub goes down again, it seems reasonable to maintain a code mirror on another reliable forge, such as [Codeberg](https://codeberg.org).

Since Codeberg will not do automatic code pulls, we must push code there ourselves. I've set up [a dedicated account](https://codeberg.org/byu-cs-discord-mirror-bot) for this purpose on [our mirror org over there](https://codeberg.org/BYU-CS-Discord), and this PR facilitates the push each time new code hits our `main` branch.