### PR TITLE
Fix `/findroom between` using buildings as `end_time` choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - All package vulnerabilities
+- Buildings being used as choices for `end_time` option of `/findroom between` command
 
 ## [0.12.1] - 2023-10-05
 

--- a/src/commands/findRoom.ts
+++ b/src/commands/findRoom.ts
@@ -181,7 +181,7 @@ const builder = new SlashCommandBuilder()
 				option
 					.setName('end_time')
 					.setDescription('What time would you like to search for?')
-					.addChoices(...bldgChoices)
+					.addChoices(...timeChoices)
 					.setRequired(true)
 			)
 			.addStringOption(option =>


### PR DESCRIPTION
Fixes #117 