### PR TITLE
chore: Also tag sha hash in Docker

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -46,6 +46,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha
 
       - name: Build and push Docker image
         # docker/build-push-action@v6.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.1] - 2024-10-03
 
-- Nothing!
+### Added
 
-## [0.13.0] - 2024-08-24
+- Deploy Docker image tags for specific SHA hashes.
+
+## [0.13.0] - 2024-10-03
 
 ### Added
 
@@ -261,7 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
-[Unreleased]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.0...HEAD
+[0.13.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.11.2...v0.12.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.13.0",
+			"version": "0.13.1",
 			"license": "0BSD",
 			"dependencies": {
 				"@discordjs/voice": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csbot",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"private": true,
 	"description": "The One beneath the Supreme Overlord's rule. A bot to help manage the BYU CS Discord, successor to Ze Kaiser (https://github.com/arkenstorm/ze-kaiser)",
 	"keywords": [


### PR DESCRIPTION
Added another Docker tag config to target specific versions. Not sure why v0.13.0 failed to deploy, so this new tag run might give me more info