### PR TITLE
Trigger tag push event from the release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,6 +29,8 @@ jobs:
         # This action doesn't create a new release if the tag already exists
         uses: softprops/action-gh-release@v1
         with:
+          # Can't use GITHUB_TOKEN for tags, or our deploy workflow won't trigger. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.RELEASE_TOKEN }}
           tag_name: v${{ steps.changelog.outputs.version }}
           name: v${{ steps.changelog.outputs.version }}
           body: ${{ steps.changelog.outputs.description }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2024-10-03
+
+### Changed
+
+- Nothing. Just triggering a CI run for science.
+
 ## [0.13.1] - 2024-10-03
 
 ### Added
@@ -263,6 +269,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
+[0.13.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.12.0...v0.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Automatic deployment of SemVer tags for our Docker image should now work.
+
 ## [0.13.2] - 2024-10-03
 
 ### Changed
@@ -269,6 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
+[Unreleased]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.2...HEAD
 [0.13.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.12.1...v0.13.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.13.1",
+	"version": "0.13.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.13.1",
+			"version": "0.13.2",
 			"license": "0BSD",
 			"dependencies": {
 				"@discordjs/voice": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csbot",
-	"version": "0.13.1",
+	"version": "0.13.2",
 	"private": true,
 	"description": "The One beneath the Supreme Overlord's rule. A bot to help manage the BYU CS Discord, successor to Ze Kaiser (https://github.com/arkenstorm/ze-kaiser)",
 	"keywords": [


### PR DESCRIPTION
Figured out why our Docker deploy was failing to push semver tags. Turns out, it's because we were using `GITHUB_TOKEN` to cut releases. [GitHub won't let `GITHUB_TOKEN` trigger another workflow.](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) 😔

I set up my own personal token for now. Eventually we may want to find a different way to run the deployments.