### PR TITLE
Remove dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1000


### PR DESCRIPTION
Dependabot has an annoying default setting where it won't open more than 5 PRs at once. According to the documentation, this is to keep updates "manageable", but in practice it makes things much harder, especially when trying to catch up on dependencies after a long pause.

If several PRs become blocked or required additional attention, the 5-PR limit can jam up or block upgrading any other dependencies (like right now). And sometimes, you need to upgrade one dependency before another, but the PR limit will soft-lock you.

In practice, we only have a few dozen dependencies, so that's the true limit. It's not unmanageable. I'd much rather see a list of PRs for every dependency that needs upgrading, instead of needing to re-run the dependency check every 5 PRs.