### PR TITLE
Add GitHub Actions updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1000
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    versioning-strategy: increase
     open-pull-requests-limit: 1000
 
   - package-ecosystem: github-actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.3] - 2025-06-12
+## [0.14.3] - 2025-06-13
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.14.3] - 2025-06-13
 
 ### Fixed
@@ -295,6 +297,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
+[Unreleased]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.3...HEAD
 [0.14.3]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.0...v0.14.1


### PR DESCRIPTION
### Dependabot

Made some changes to reflect what I've done in personal projects.

- Added updates for GitHub Actions
- Set versioning strategy to "increase" (this fixes situations where dependabot only updates `package-lock.json` without bumping the version in `package.json`)

### Changelog

- Fixed the last update's release date
- Fixed the missing "Unreleased" section