### PR TITLE
GET a configured URL every so often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `UPTIME_URL` and `UPTIME_INTERVAL_SECONDS` env vars to configure a regular ping to an uptime-notifier service such as [uptime-kuma](https://github.com/louislam/uptime-kuma).
+
 ## [0.14.3] - 2025-06-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2025-09-25
+
 ### Added
 
 - New `UPTIME_URL` and `UPTIME_INTERVAL_SECONDS` env vars to configure a regular ping to an uptime-notifier service such as [uptime-kuma](https://github.com/louislam/uptime-kuma).
@@ -301,7 +303,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Development Environment for needed dependencies.
 
-[Unreleased]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.3...HEAD
+[Unreleased]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/BYU-CS-Discord/CSBot/compare/v0.14.0...v0.14.1

--- a/README.md
+++ b/README.md
@@ -172,11 +172,17 @@ Create a file called `.env` in the root of this project folder. Paste your token
 ```sh
 # .env
 
-DISCORD_TOKEN=YOUR_TOKEN_GOES_HERE
-# Required, token for your Discord bot
+# Required; token for your Discord bot
+DISCORD_TOKEN='xxx'
 
-DATABASE_URL=YOUR_DATABASE_URL_GOES_HERE
-# Required for any DB functionality, we will get this URL in a later section
+# Required; facilitates DB functionality, we will get this URL in a later section
+DATABASE_URL='file:/path/to/your/database.db'
+
+# Optional; a URL to GET periodically, e.g. an uptime-kuma Push Monitor
+UPTIME_URL='https://status.example.com/api/push/xxx?status=up'
+
+# Optional; the number of seconds between calls to `UPTIME_URL` Must be at least 15. Defaults to `300`
+UPTIME_INTERVAL_SECONDS=300
 ```
 
 **Do not commit this file to git** or your bot _will_ get "hacked".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csbot",
-	"version": "0.14.3",
+	"version": "0.15.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csbot",
-			"version": "0.14.3",
+			"version": "0.15.0",
 			"license": "0BSD",
 			"dependencies": {
 				"@discordjs/voice": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csbot",
-	"version": "0.14.3",
+	"version": "0.15.0",
 	"private": true,
 	"description": "The One beneath the Supreme Overlord's rule. A bot to help manage the BYU CS Discord, successor to Ze Kaiser (https://github.com/arkenstorm/ze-kaiser)",
 	"keywords": [

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,5 +1,6 @@
 import type { Client, ClientPresence } from 'discord.js';
 import { ActivityType } from 'discord.js';
+import { Worker } from 'node:worker_threads';
 
 import { appVersion } from '../constants/meta.js';
 import { deployCommands } from '../helpers/actions/deployCommands.js';
@@ -40,6 +41,16 @@ export const ready = onEvent('ready', {
 		// Set user activity
 		info('Setting user activity');
 		setActivity(client);
+
+		// Start uptime ping
+		const UPTIME_URL = process.env['UPTIME_URL'];
+		if (UPTIME_URL) {
+			const UPTIME_INTERVAL_SECONDS = process.env['UPTIME_INTERVAL_SECONDS'];
+			new Worker(new URL('../workers/uptime.js', import.meta.url), {
+				name: 'uptime-ping',
+				env: { UPTIME_URL, UPTIME_INTERVAL_SECONDS },
+			});
+		}
 
 		info('Ready!');
 	},

--- a/src/workers/uptime.ts
+++ b/src/workers/uptime.ts
@@ -1,28 +1,36 @@
 // Note: This file should never be imported or rolled into a bundle.
 // The path to this file is passed into `node:worker_threads`.
 
+/* eslint-disable no-console */
+
 let UPTIME_URL: URL;
 try {
-	UPTIME_URL = new URL(process.env['UPTIME_URL'] ?? "");
+	UPTIME_URL = new URL(process.env['UPTIME_URL'] ?? '');
 } catch (error) {
-	console.error("[uptime] UPTIME_URL is invalid:", error);
+	console.error('[uptime] UPTIME_URL is invalid:', error);
+	// eslint-disable-next-line unicorn/no-process-exit
 	process.exit(1); // exit the worker thread
 }
 
 // If interval is missing or invalid, use 300s
-let UPTIME_INTERVAL_SECONDS = Number(process.env['UPTIME_INTERVAL_SECONDS'] ?? "300");
+let UPTIME_INTERVAL_SECONDS = Number(process.env['UPTIME_INTERVAL_SECONDS'] ?? '300');
 if (Number.isNaN(UPTIME_INTERVAL_SECONDS) || UPTIME_INTERVAL_SECONDS <= 15) {
 	UPTIME_INTERVAL_SECONDS = 300;
 }
-const delayMs = UPTIME_INTERVAL_SECONDS * 1_000;
+const delayMs = UPTIME_INTERVAL_SECONDS * 1000;
 
 console.info(`[uptime] Ready to ping every ${UPTIME_INTERVAL_SECONDS}s at endpoint: ${UPTIME_URL}`);
 
-setInterval(async (url: URL) => {
-	try {
-		await fetch(url);
-		console.info("[uptime] Ping!");
-	} catch (error) {
-		console.error("[uptime] Failed to ping:", error)
-	}
-}, delayMs, UPTIME_URL);
+setInterval(
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	async (url: URL) => {
+		try {
+			await fetch(url);
+			console.info('[uptime] Ping!');
+		} catch (error) {
+			console.error('[uptime] Failed to ping:', error);
+		}
+	},
+	delayMs,
+	UPTIME_URL
+);

--- a/src/workers/uptime.ts
+++ b/src/workers/uptime.ts
@@ -1,0 +1,28 @@
+// Note: This file should never be imported or rolled into a bundle.
+// The path to this file is passed into `node:worker_threads`.
+
+let UPTIME_URL: URL;
+try {
+	UPTIME_URL = new URL(process.env['UPTIME_URL'] ?? "");
+} catch (error) {
+	console.error("[uptime] UPTIME_URL is invalid:", error);
+	process.exit(1); // exit the worker thread
+}
+
+// If interval is missing or invalid, use 300s
+let UPTIME_INTERVAL_SECONDS = Number(process.env['UPTIME_INTERVAL_SECONDS'] ?? "300");
+if (Number.isNaN(UPTIME_INTERVAL_SECONDS) || UPTIME_INTERVAL_SECONDS <= 15) {
+	UPTIME_INTERVAL_SECONDS = 300;
+}
+const delayMs = UPTIME_INTERVAL_SECONDS * 1_000;
+
+console.info(`[uptime] Ready to ping every ${UPTIME_INTERVAL_SECONDS}s at endpoint: ${UPTIME_URL}`);
+
+setInterval(async (url: URL) => {
+	try {
+		await fetch(url);
+		console.info("[uptime] Ping!");
+	} catch (error) {
+		console.error("[uptime] Failed to ping:", error)
+	}
+}, delayMs, UPTIME_URL);


### PR DESCRIPTION
Would be nice to have some kind of status page. I have an Uptime Kuma instance at https://status.byucs.genericlookinglink.com that so far only shows the RoomFinder back-end. We can additionally configure a monitor to receive GET requests from CSBot every so often to indicate up-ness.

This PR adds configuration options for that URL and the ping interval, and runs a loop on a worker thread to ping the back-end, with reasonable logging.

I also cut a new version, since I kinda want this out as soon as we can :sweat_smile: 