### PR TITLE
Use `clientReady` event instead of `ready`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** set minimum Node version to 22.18.0
 - **Breaking:** upgrade to Node 24
 - Replace `nodemon` with `node --watch` for the `npm run dev` script
+- Use `clientReady` event instead of `ready` to fix deprecation warning
 - Use `Events` enum for event handler names
 - Replace `tsx` with native Node for `release.ts` script
 - Replace `jiti` with native Node for loading `eslint.config.ts`

--- a/src/events/clientReady.test.ts
+++ b/src/events/clientReady.test.ts
@@ -29,9 +29,9 @@ const mockVerifyCommandDeployments = verifyCommandDeployments as Mock<
 vi.mock('../logger.js');
 
 // Import the code to test
-import { ready } from './ready.js';
+import { clientReady } from './clientReady.js';
 
-describe('once(ready)', () => {
+describe('once(clientReady)', () => {
 	const client = {
 		user: { username: 'Ze Kaiser Jr.' },
 		destroy() {
@@ -56,7 +56,7 @@ describe('once(ready)', () => {
 			deploy: false,
 			revoke: false,
 		});
-		await ready.execute(client);
+		await clientReady.execute(client);
 		expect(mockDeployCommands).not.toHaveBeenCalled();
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
@@ -66,7 +66,7 @@ describe('once(ready)', () => {
 			deploy: true,
 			revoke: false,
 		});
-		await ready.execute(client);
+		await clientReady.execute(client);
 		expect(mockDeployCommands).toHaveBeenCalledWith(client);
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
@@ -76,7 +76,7 @@ describe('once(ready)', () => {
 			deploy: false,
 			revoke: true,
 		});
-		await ready.execute(client);
+		await clientReady.execute(client);
 		expect(mockDeployCommands).not.toHaveBeenCalled();
 		expect(mockRevokeCommands).toHaveBeenCalledWith(client);
 	});
@@ -86,13 +86,13 @@ describe('once(ready)', () => {
 			deploy: true,
 			revoke: true,
 		});
-		await ready.execute(client);
+		await clientReady.execute(client);
 		expect(mockDeployCommands).toHaveBeenCalledWith(client);
 		expect(mockRevokeCommands).not.toHaveBeenCalled();
 	});
 
 	test('verifies command deployments', async () => {
-		await ready.execute(client);
+		await clientReady.execute(client);
 		expect(mockVerifyCommandDeployments).toHaveBeenCalledWith(client);
 	});
 });

--- a/src/events/clientReady.ts
+++ b/src/events/clientReady.ts
@@ -12,7 +12,7 @@ import { info } from '../logger.js';
 /**
  * The event handler for when the Discord Client is ready for action
  */
-export const ready = onEvent(Events.ClientReady, {
+export const clientReady = onEvent(Events.ClientReady, {
 	once: true,
 	async execute(client) {
 		info(`Starting ${client.user.username} v${appVersion}...`);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -53,15 +53,15 @@ export function registerEventHandlers(client: Client): void {
 }
 
 // Install event handlers
+import { clientReady } from './clientReady.js';
 import { error } from './error.js';
 import { interactionCreate } from './interactionCreate.js';
 import { messageReactionAdd } from './messageReactionAdd.js';
 import { messageReactionRemove } from './messageReactionRemove.js';
-import { ready } from './ready.js';
 
+_add(clientReady as EventHandler);
 _add(error as EventHandler);
 _add(interactionCreate as EventHandler);
 _add(messageReactionAdd as EventHandler);
 _add(messageReactionRemove as EventHandler);
-_add(ready as EventHandler);
 // Not sure why these type casts are necessary, but they seem sound. We can remove them when TS gets smarter, or we learn what I did wrong


### PR DESCRIPTION
Fixes a deprecation warning

```
(node:19852) DeprecationWarning: The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```