### PR TITLE
fix(docker): update package lists to find openssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,25 @@ jobs:
       - name: Type check
         run: npm run type-check
 
+  try-docker:
+    name: Test Docker build
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Required for actions/checkout
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+
   test:
     name: Test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM node:24-slim AS runner
 
 ENV NODE_ENV=production
 
-RUN apt-get install -y openssl
+RUN apt-get update && apt-get install -y openssl
 
 WORKDIR /app
 


### PR DESCRIPTION
Ok so I finally actually tested the dockerfile locally (with Podman, not Docker proper, so :crossed_fingers:) and it looks like this time it has trouble finding the `openssl` package, so I suppose we must update the package lists when we run the install.

I also added a CI step to attempt building the Dockerfile, so we can catch this next time we break it, lol