### PR TITLE
fix(dependabot): bump codeql actions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
     open-pull-requests-limit: 1000


### PR DESCRIPTION
Dependabot used to do this automatically somehow, but now seems to treat those actions separately :confused: (see https://github.com/BYU-CS-Discord/CSBot/pull/583#issuecomment-4977698281)

Oh well, easy fix!